### PR TITLE
Fixed the test that was failing sometimes

### DIFF
--- a/platform/src/main/java/org/hillview/sketches/FullCorrelationSketch.java
+++ b/platform/src/main/java/org/hillview/sketches/FullCorrelationSketch.java
@@ -69,6 +69,10 @@ public class FullCorrelationSketch implements ISketch<ITable, CorrMatrix> {
         left = Converters.checkNull(left);
         right = Converters.checkNull(right);
 
+        // Return a zero when adding two zeros.
+        if (left.count == 0 && right.count == 0)
+            return this.zero();
+
         CorrMatrix result = new CorrMatrix(this.colNames);
         double alpha = (double) left.count / (left.count + right.count);
 

--- a/platform/src/test/java/org/hillview/sketch/CorrelationTest.java
+++ b/platform/src/test/java/org/hillview/sketch/CorrelationTest.java
@@ -22,7 +22,6 @@ public class CorrelationTest {
     @Test
     public void testCorrelation() {
         DoubleMatrix mat = new DoubleMatrix(new double[][]{{9, 8, 4, 1, 6}, {5, 8, 2, 10, 1}, {6, 4, 1, 6, 5}});
-//        [[9, 8, 4, 1, 6], [5, 8, 2, 10, 1], [6, 4, 1, 6, 5]]
         ITable table = BlasConversions.toTable(mat);
         List<String> colNames = new ArrayList<String>(table.getSchema().getColumnNames());
 
@@ -45,7 +44,7 @@ public class CorrelationTest {
         }
     }
 
-    //@Test
+    @Test
     public void testBigCorrelation() {
         Random.seed(43);
         DoubleMatrix mat = DoubleMatrix.rand(20000, 5);


### PR DESCRIPTION
The reason the test failed was that the sketch was unable to `add` two `zero`s, resulting in a `NaN` in the result. The sketch is able to cope with this now. (But it is still interesting that there are siblings that are both `zero`s.)

The result of the sketch is still non-deterministic in the sense that there are very small variations, caused by (I think) variations in floating point accuracy due to the exact order of when the different leafs of the dataset are merged, or on how the tree is structured exactly.