### PR TITLE
Fix for compilation error

### DIFF
--- a/web/src/main/java/org/hillview/TableTarget.java
+++ b/web/src/main/java/org/hillview/TableTarget.java
@@ -281,7 +281,8 @@ public final class TableTarget extends RpcTarget {
     }
 
     HeavyHittersTarget getHHI(FreqKList fkList) {
-        return new HeavyHittersTarget(fkList.filter());
+        fkList.filter();
+        return new HeavyHittersTarget(fkList);
     }
 
     @HillviewRpc


### PR DESCRIPTION
The `web` project wasn't compiling, as the `FreqKList.filter()` method returns void, whereas a `FreqKList` object is expected.