### PR TITLE
Fixed the error message on resizing the heat map array

### DIFF
--- a/web/src/main/webapp/rpc.ts
+++ b/web/src/main/webapp/rpc.ts
@@ -143,12 +143,16 @@ export class RpcRequest implements ICancellable {
                 if (reply.isError) {
                     onReply.onError(reply.result);
                 } else {
+                    let success = false;
+                    let response: any;
                     try {
-                        let response = <T>JSON.parse(reply.result);
-                        onReply.onNext(response);
+                        response = <T>JSON.parse(reply.result);
+                        success = true;
                     } catch (e) {
                         onReply.onError(e);
                     }
+                    if (success)
+                        onReply.onNext(response);
                 }
             };
             this.socket.onopen = () => {


### PR DESCRIPTION
It was caused by the fact that if you change the size repeatedly (and quickly), the z-bins (category names) where updated while the heatmaps were being drawn, resulting in the code trying to access a property of something that doesn't exist. I solved this by making the array of z-bins not a global object, but an object that goes through the request pipeline, so that it is associated to only a single HeatMap3D request, and there are no inconsistencies.

The error wasn't visible to me before, as somehow it's more prominent in Firefox. (Slower JavaScript engine, perhaps?)

I've also changed the `rpc.ts` file, as it caught this error, which made it harder to debug. The `try-catch` block was meant for the JSON parsing, but it caught errors in the drawing functions, which should not be the case, I think. Now I could see the stack trace that the Chrome console gives.