### PR TITLE
Made a reusable class for the position/count display

### DIFF
--- a/web/src/main/webapp/hillview.css
+++ b/web/src/main/webapp/hillview.css
@@ -198,23 +198,19 @@ th, td {
     stroke-dasharray: 5,5
 }
 
-.dataRange > svg {
+svg.dataRange {
     width: 100px;
     height: 10px;
     display: inline-block;
     background: rgb(220, 220, 220);
 }
 
-.dataRange > svg > g {
+svg.dataRange > g {
     transform: scale(100, 10);
 }
 
-.dataRange > svg > g > rect {
+svg.dataRange > g > rect {
     fill: black;
-}
-
-.dataRange > div {
-    display: inline-block;
 }
 
 table.menu {

--- a/web/src/main/webapp/table.ts
+++ b/web/src/main/webapp/table.ts
@@ -35,6 +35,7 @@ import {
 import {CategoryCache} from "./categoryCache";
 import {HeatMapArrayDialog} from "./heatMapArray";
 import {ColumnConverter} from "./columnConverter";
+import {DataRange} from "./vis"
 
 // This is the serialization of a NextKList Java object
 export class TableDataView {
@@ -767,27 +768,14 @@ export class TableView extends RemoteTableObjectView
             return "?";  // TODO
     }
 
-    private drawDataRange(cell: HTMLElement, position: number, count: number) : void {
-        let w = Math.max(0.01, count / this.rowCount);
-        let x = position / this.rowCount;
-        if (x + w > 1)
-            x = 1 - w;
-        cell.classList.add('dataRange');
-        d3.select(cell).append('svg')
-            .append("g").append("rect")
-            .attr("x", x)
-            .attr("y", 0)
-            .attr("width", w) // 0.01 corresponds to 1 pixel
-            .attr("height", 1);
-    }
-
     public addRow(row : RowView, cds: ColumnDescription[]) : void {
         let trow = this.tBody.insertRow();
 
         let position = this.startPosition + this.dataRowsDisplayed;
 
         let cell = trow.insertCell(0);
-        this.drawDataRange(cell, position, row.count);
+        let dataRange = new DataRange(position, row.count, this.rowCount);
+        cell.appendChild(dataRange.getDOMRepresentation());
 
         cell = trow.insertCell(1);
         cell.style.textAlign = "right";

--- a/web/src/main/webapp/ui.ts
+++ b/web/src/main/webapp/ui.ts
@@ -23,6 +23,10 @@ export interface IHtmlElement {
     getHTMLRepresentation() : HTMLElement;
 }
 
+export interface IElement {
+    getDOMRepresentation(): Element;
+}
+
 export enum KeyCodes {
     enter = 13,
     ctrl = 17,

--- a/web/src/main/webapp/vis.ts
+++ b/web/src/main/webapp/vis.ts
@@ -105,13 +105,23 @@ export class ColorMap {
     }
 }
 
+/**
+ * This class displays the relative size of a subsequence within a sequence,
+ * in a bar.
+ */
 export class DataRange implements IElement {
     private topLevel: Element;
 
+    /**
+     * @param position: Index where the subsequence starts.
+     * @param count: Number of items in the subsequence.
+     * @param totalCount: Total number of items in the 'supersequence'.
+     */
     constructor(position: number, count: number, totalCount: number) {
             this.topLevel = document.createElementNS("http://www.w3.org/2000/svg", "svg")
             this.topLevel.classList.add("dataRange");
-            // If the range represents < 1 % of the total count, use 1% of the bar's width.
+            // If the range represents < 1 % of the total count, use 1% of the
+            // bar's width, s.t. it is still visible.
             let w = Math.max(0.01, count / totalCount);
             let x = position / totalCount;
             if (x + w > 1)

--- a/web/src/main/webapp/vis.ts
+++ b/web/src/main/webapp/vis.ts
@@ -1,5 +1,5 @@
 import d3 = require("d3");
-import {Size} from "./ui";
+import {Size, IElement} from "./ui";
 
 export class ColorMap {
     public logScale: boolean;
@@ -102,5 +102,29 @@ export class ColorMap {
 
         let axis = this.getAxis(size.width, ticks, base, true);
         axisG.call(axis);
+    }
+}
+
+export class DataRange implements IElement {
+    private topLevel: Element;
+
+    constructor(position: number, count: number, totalCount: number) {
+            this.topLevel = document.createElementNS("http://www.w3.org/2000/svg", "svg")
+            this.topLevel.classList.add("dataRange");
+            // If the range represents < 1 % of the total count, use 1% of the bar's width.
+            let w = Math.max(0.01, count / totalCount);
+            let x = position / totalCount;
+            if (x + w > 1)
+            x = 1 - w;
+            d3.select(this.topLevel)
+                .append("g").append("rect")
+                .attr("x", x)
+                .attr("y", 0)
+                .attr("width", w)
+                .attr("height", 1);
+        }
+
+    public getDOMRepresentation(): Element {
+        return this.topLevel;
     }
 }


### PR DESCRIPTION
I've created a new interface, `IElement`, which is an interface for something more general than `IHtmlElement`. Perhaps `IHtmlElement` can be replaced by this new interface? The reason is that [`SVGElement`](https://developer.mozilla.org/en-US/docs/Web/API/SVGElement)s are not [`HTMLElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement)s, as they live in their own namespace. They *are* both [`Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element)s though.