### PR TITLE
Fixed text alignment issues in Firefox.

### DIFF
--- a/web/src/main/webapp/heatMapArray.ts
+++ b/web/src/main/webapp/heatMapArray.ts
@@ -111,9 +111,8 @@ export class CompactHeatMapView {
         this.g.append("text")
             .text(binLabel)
             .attr("text-anchor", "middle")
-            .attr("alignment-baseline", "middle")
             .attr("x", this.size.width / 2)
-            .attr("y", Resolution.lineHeight / 2)
+            .attr("y", Resolution.lineHeight)
 
 
         this.chart = this.g.append("g")
@@ -188,19 +187,6 @@ export class CompactHeatMapView {
             .attr("class", "y-axis")
             .call(this.yAxis);
 
-        // Draw axis labels
-        this.axesG.append("text")
-            .text(this.yAxisData.description.name)
-            .attr("transform-origin", "center top")
-            .attr("text-anchor", "middle")
-            .attr("alignment-baseline", "hanging")
-            .attr("transform", `translate(${-Resolution.leftMargin}, ${0.5 * this.chartSize.height})rotate(-90)`);
-        this.axesG.append("text")
-            .text(this.xAxisData.description.name)
-            .attr("text-anchor", "middle")
-            .attr("alignment-baseline", "baseline")
-            .attr("transform", `translate(${0.5 * this.chartSize.width}, ${this.chartSize.height + Resolution.bottomMargin - 5})`);
-
         // Draw a visual indicator with a circle and two lines.
         this.marker = this.axesG.append("circle")
             .attr("r", 4)
@@ -229,11 +215,9 @@ export class CompactHeatMapView {
             .attr("fill", "rgba(255, 255, 255, 0.9)");
         // Draw the values as strings.
         this.xText = this.axesG.append("text")
-            .attr("text-anchor", "left")
-            .attr("alignment-baseline", "baseline")
+            .attr("text-anchor", "left");
         this.yText = this.axesG.append("text")
-            .attr("text-anchor", "left")
-            .attr("alignment-baseline", "baseline")
+            .attr("text-anchor", "left");
     }
 
     // Returns the value (count in the histogram) under the mouse.

--- a/web/src/main/webapp/hillview.css
+++ b/web/src/main/webapp/hillview.css
@@ -295,6 +295,7 @@ table.dropdown {
 div.colorLegend {
     display: flex;
     justify-content: center;
+    margin: 5px;
 }
 
 div.colorLegend > svg {

--- a/web/src/main/webapp/vis.ts
+++ b/web/src/main/webapp/vis.ts
@@ -152,8 +152,7 @@ export class ColorLegend implements IHtmlElement {
         this.textIndicator = svg.append("text").attr("id", "text-indicator")
             .attr("x", "50%")
             .attr("y", "100%")
-            .attr("text-anchor", "middle")
-            .attr("alignment-baseline", "bottom");
+            .attr("text-anchor", "middle");
 
         let axis = this.getAxis();
         axisG.call(axis);


### PR DESCRIPTION
Somehow, Firefox doesn't render svg text elements according to the W3C standards.. To support all browsers, I guess it's better not to use the `alignment-baseline` property of svg `<text>` elements for now.

I also removed the redundant axis labels in the heat map array view. Now they're only visible in the rectangle that shows the values as well.