### PR TITLE
Fix auto select of LAMP columns for heat map array

### DIFF
--- a/web/src/main/webapp/lamp.ts
+++ b/web/src/main/webapp/lamp.ts
@@ -285,7 +285,7 @@ class ControlPointsView extends RemoteTableObjectView {
 
     private heatMap3D() {
         let rr = this.lampTableObject.createGetSchemaRequest();
-        rr.invoke(new SchemaCollector(this.getPage(), rr, this.lampTableObject, []));
+        rr.invoke(new SchemaCollector(this.getPage(), rr, this.lampTableObject, this.lampColNames));
     }
 }
 


### PR DESCRIPTION
The dialog now auto-selects the LAMP columns if it is evoked from the LAMP view.