### PR TITLE
Add bottom margin for heatmap array

### DIFF
--- a/web/src/main/webapp/hillview.css
+++ b/web/src/main/webapp/hillview.css
@@ -261,6 +261,7 @@ table.dropdown {
     justify-content: center;
     align-items: stretch;
     text-align: center;
+    margin-bottom: 20px;
 }
 
 .lampView > div {


### PR DESCRIPTION
Otherwise the axis labels aren't visible if the heatmap array is the last `FullPage`.