### PR TITLE
TopK performance improvements

### DIFF
--- a/bin/demo-backend-start.sh
+++ b/bin/demo-backend-start.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cd ../platform/
-java -jar target/hillview-server-jar-with-dependencies.jar 127.0.0.1:3569
+java -server -jar target/hillview-server-jar-with-dependencies.jar 127.0.0.1:3569

--- a/platform/src/main/java/org/hillview/sketches/HeapTopK.java
+++ b/platform/src/main/java/org/hillview/sketches/HeapTopK.java
@@ -17,6 +17,10 @@
 
 package org.hillview.sketches;
 
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2IntRBTreeMap;
+import it.unimi.dsi.fastutil.objects.Object2IntSortedMap;
+
 import javax.annotation.Nullable;
 import java.util.*;
 /**
@@ -27,7 +31,7 @@ import java.util.*;
 public class HeapTopK<T> implements ITopK<T> {
     private final int maxSize;
     private int size;
-    private final HashMap<T, Integer> data;
+    private final Object2IntOpenHashMap<T> data;
     @Nullable
     private T cutoff; /* max value that currently belongs to Top K. */
     private final Comparator<T> greater;
@@ -39,12 +43,12 @@ public class HeapTopK<T> implements ITopK<T> {
             throw new IllegalArgumentException("Size should be positive");
         this.size = 0;
         this.greater = greater;
-        this.data = new HashMap<T, Integer>();
+        this.data = new Object2IntOpenHashMap<T>();
     }
 
     @Override
-    public SortedMap<T, Integer> getTopK() {
-        final SortedMap<T, Integer> finalMap = new TreeMap<T, Integer>(this.greater);
+    public Object2IntSortedMap<T> getTopK() {
+        final Object2IntSortedMap<T> finalMap = new Object2IntRBTreeMap<>(this.greater);
         finalMap.putAll(this.data);
         return finalMap;
     }

--- a/platform/src/main/java/org/hillview/sketches/ITopK.java
+++ b/platform/src/main/java/org/hillview/sketches/ITopK.java
@@ -29,6 +29,6 @@ import java.util.SortedMap;
  * - Insert: If we need to Insert newVal
  */
 interface ITopK<T> {
-    SortedMap<T,Integer> getTopK();
+    SortedMap<T, Integer> getTopK();
     void push(T newVal);
 }

--- a/platform/src/main/java/org/hillview/sketches/IntTreeTopK.java
+++ b/platform/src/main/java/org/hillview/sketches/IntTreeTopK.java
@@ -17,60 +17,70 @@
 
 package org.hillview.sketches;
 
+import it.unimi.dsi.fastutil.ints.Int2IntRBTreeMap;
+import it.unimi.dsi.fastutil.ints.Int2IntSortedMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
+import it.unimi.dsi.fastutil.ints.IntComparator;
 import it.unimi.dsi.fastutil.objects.Object2IntRBTreeMap;
 import it.unimi.dsi.fastutil.objects.Object2IntSortedMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectRBTreeMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectSortedMap;
 import org.hillview.utils.MutableInteger;
 
 import javax.annotation.Nullable;
 import java.util.Comparator;
 import java.util.SortedMap;
+import java.util.TreeMap;
 
 /**
- * Implements the ITopK interface as a SortedMap (which uses Red-Black trees).
- * Seems faster than HashMap implementation.
+ * Implements an int specialized version of the ITopK interface. Reduces boxing
+ * overheads in comparison to the TreeTopK class.
  */
-public class TreeTopK<T> implements ITopK<T> {
+public class IntTreeTopK implements ITopK<Integer> {
     private final int maxSize;
     private int size;
-    private final SortedMap<T, MutableInteger> data;
-    @Nullable
-    private T cutoff; /* max value that currently belongs to Top K. */
-    private final Comparator<T> greater;
+    private final Int2ObjectRBTreeMap<MutableInteger> data;
+    private int cutoff; /* max value that currently belongs to Top K. */
+    private final IntComparator greater;
 
-    public TreeTopK(final int maxSize, final Comparator<T> greater) {
+    public IntTreeTopK(final int maxSize, final IntComparator greater) {
         this.maxSize = maxSize;
         this.size = 0;
         this.greater = greater;
-        this.data = new Object2ObjectRBTreeMap<>(this.greater);
+        this.data = new Int2ObjectRBTreeMap<MutableInteger>(this.greater);
     }
 
-    @Override
-    public SortedMap<T, Integer> getTopK() {
-        final Object2IntSortedMap<T> finalMap = new Object2IntRBTreeMap<>(this.greater);
-        this.data.forEach((k, v) -> finalMap.put(k, v.get()));
+    public Int2IntSortedMap getTopK() {
+        final Int2IntSortedMap finalMap = new Int2IntRBTreeMap(this.greater);
+        this.data.forEach((k, v) -> finalMap.put(k.intValue(), v.get()));
         return finalMap;
     }
 
+    @Deprecated
     @Override
-    public void push(final T newVal) {
+    public void push(final Integer newVal) {
+        push(newVal.intValue());
+    }
+
+    public void push(final int intVal) {
         if (this.size == 0) {
-            this.data.put(newVal, new MutableInteger(1)); // Add newVal to Top K
-            this.cutoff = newVal;
+            this.data.put(intVal, new MutableInteger(1)); // Add newVal to Top K
+            this.cutoff = intVal;
             this.size = 1;
             return;
         }
-        final int gt = this.greater.compare(newVal, this.cutoff);
+        final int gt = this.greater.compare(intVal, this.cutoff);
         if (gt <= 0) {
-            final MutableInteger counter = this.data.get(newVal);
+            final MutableInteger counter = this.data.get(intVal);
             if (counter != null) { //Already in Top K, increase count. Size, cutoff do not change
                 final int count = counter.get() + 1;
                 counter.set(count);
             } else { // Add a new key to Top K
-                this.data.put(newVal, new MutableInteger(1));
+                this.data.put(intVal, new MutableInteger(1));
                 if (this.size >= this.maxSize) {        // Remove the largest key, compute the new largest key
                     this.data.remove(this.cutoff);
-                    this.cutoff = this.data.lastKey();
+                    this.cutoff = this.data.lastIntKey();
                 } else {
                     this.size += 1;
                 }
@@ -78,8 +88,8 @@ public class TreeTopK<T> implements ITopK<T> {
         } else {   // gt equals 1
             if (this.size < this.maxSize) {   // Only case where newVal needs to be added
                 this.size += 1;
-                this.data.put(newVal, new MutableInteger(1));     // Add newVal to Top K
-                this.cutoff = newVal;    // It is now the largest value
+                this.data.put(intVal, new MutableInteger(1));     // Add newVal to Top K
+                this.cutoff = intVal;    // It is now the largest value
             }
         }
     }

--- a/platform/src/main/java/org/hillview/sketches/NextKSketch.java
+++ b/platform/src/main/java/org/hillview/sketches/NextKSketch.java
@@ -17,6 +17,8 @@
 
 package org.hillview.sketches;
 
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntSortedMap;
 import org.hillview.dataset.api.ISketch;
 import org.hillview.table.*;
 import org.hillview.table.api.*;
@@ -78,7 +80,7 @@ public class NextKSketch implements ISketch<ITable, NextKList> {
         SortedMap<Integer, Integer> topKList = topK.getTopK();
         IRowOrder rowOrder = new ArrayRowOrder(topKList.keySet());
         SmallTable topKRows = data.compress(this.recordOrder.toSubSchema(), rowOrder);
-        List<Integer> count = new ArrayList<Integer>();
+        List<Integer> count = new ArrayList<Integer>(topKList.size());
         count.addAll(topKList.values());
         return new NextKList(topKRows, count, position, data.getNumOfRows());
     }

--- a/platform/src/main/java/org/hillview/sketches/NextKSketch.java
+++ b/platform/src/main/java/org/hillview/sketches/NextKSketch.java
@@ -17,8 +17,7 @@
 
 package org.hillview.sketches;
 
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Object2IntSortedMap;
+import it.unimi.dsi.fastutil.ints.Int2IntSortedMap;
 import org.hillview.dataset.api.ISketch;
 import org.hillview.table.*;
 import org.hillview.table.api.*;
@@ -63,7 +62,7 @@ public class NextKSketch implements ISketch<ITable, NextKList> {
     @Override
     public NextKList create(ITable data) {
         IndexComparator comp = this.recordOrder.getComparator(data);
-        TreeTopK<Integer> topK = new TreeTopK<Integer>(this.maxSize, comp);
+        IntTreeTopK topK = new IntTreeTopK(this.maxSize, comp);
         IRowIterator rowIt = data.getRowIterator();
         int i = rowIt.getNextRow();
         int position = 0;
@@ -77,7 +76,7 @@ public class NextKSketch implements ISketch<ITable, NextKList> {
                 position++;
             i = rowIt.getNextRow();
         }
-        SortedMap<Integer, Integer> topKList = topK.getTopK();
+        Int2IntSortedMap topKList = topK.getTopK();
         IRowOrder rowOrder = new ArrayRowOrder(topKList.keySet());
         SmallTable topKRows = data.compress(this.recordOrder.toSubSchema(), rowOrder);
         List<Integer> count = new ArrayList<Integer>(topKList.size());

--- a/platform/src/main/java/org/hillview/table/ListComparator.java
+++ b/platform/src/main/java/org/hillview/table/ListComparator.java
@@ -30,7 +30,7 @@ public class ListComparator extends IndexComparator {
     }
 
     @Override
-    public int compare(final Integer o1, final Integer o2) {
+    public int compare(final int o1, final int o2) {
         for (int i = 0; i < this.comparatorList.size() ; i++) {
             final int val = this.comparatorList.get(i).compare(o1, o2);
             if (val != 0) { return val; }

--- a/platform/src/main/java/org/hillview/table/ListComparator.java
+++ b/platform/src/main/java/org/hillview/table/ListComparator.java
@@ -19,19 +19,20 @@ package org.hillview.table;
 
 import org.hillview.table.api.IndexComparator;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ListComparator extends IndexComparator {
-    private final List<IndexComparator> comparatorList;
+    private final ArrayList<IndexComparator> comparatorList;
 
-    public ListComparator(final List<IndexComparator> comparatorList) {
+    public ListComparator(final ArrayList<IndexComparator> comparatorList) {
         this.comparatorList = comparatorList;
     }
 
     @Override
     public int compare(final Integer o1, final Integer o2) {
-        for (final IndexComparator aComparator : this.comparatorList) {
-            final int val = aComparator.compare(o1, o2);
+        for (int i = 0; i < this.comparatorList.size() ; i++) {
+            final int val = this.comparatorList.get(i).compare(o1, o2);
             if (val != 0) { return val; }
         }
         return 0;

--- a/platform/src/main/java/org/hillview/table/RecordOrder.java
+++ b/platform/src/main/java/org/hillview/table/RecordOrder.java
@@ -79,7 +79,7 @@ public class RecordOrder implements Iterable<ColumnSortOrientation>, Serializabl
      * @return A Comparator that compares two records based on the RecordOrder specified.
      */
     public IndexComparator getComparator(final ITable table) {
-        final List<IndexComparator> comparatorList = new ArrayList<IndexComparator>();
+        final ArrayList<IndexComparator> comparatorList = new ArrayList<IndexComparator>();
         ColumnAndConverterDescription[] ccds =
                 new ColumnAndConverterDescription[this.sortOrientationList.size()];
         for (int i=0; i < this.sortOrientationList.size(); i++) {

--- a/platform/src/main/java/org/hillview/table/api/IDateColumn.java
+++ b/platform/src/main/java/org/hillview/table/api/IDateColumn.java
@@ -44,7 +44,7 @@ public interface IDateColumn extends IColumn {
     default IndexComparator getComparator() {
         return new IndexComparator() {
             @Override
-            public int compare(final Integer i, final Integer j) {
+            public int compare(final int i, final int j) {
                 final boolean iMissing = IDateColumn.this.isMissing(i);
                 final boolean jMissing = IDateColumn.this.isMissing(j);
                 if (iMissing && jMissing) {

--- a/platform/src/main/java/org/hillview/table/api/IDoubleColumn.java
+++ b/platform/src/main/java/org/hillview/table/api/IDoubleColumn.java
@@ -41,7 +41,7 @@ public interface IDoubleColumn extends IColumn {
     default IndexComparator getComparator() {
         return new IndexComparator() {
             @Override
-            public int compare(final Integer i, final Integer j) {
+            public int compare(final int i, final int j) {
                 final boolean iMissing = IDoubleColumn.this.isMissing(i);
                 final boolean jMissing = IDoubleColumn.this.isMissing(j);
                 if (iMissing && jMissing) {

--- a/platform/src/main/java/org/hillview/table/api/IDurationColumn.java
+++ b/platform/src/main/java/org/hillview/table/api/IDurationColumn.java
@@ -44,7 +44,7 @@ public interface IDurationColumn extends IColumn {
     default IndexComparator getComparator() {
         return new IndexComparator() {
             @Override
-            public int compare(final Integer i, final Integer j) {
+            public int compare(final int i, final int j) {
                 final boolean iMissing = IDurationColumn.this.isMissing(i);
                 final boolean jMissing = IDurationColumn.this.isMissing(j);
                 if (iMissing && jMissing) {

--- a/platform/src/main/java/org/hillview/table/api/IIntColumn.java
+++ b/platform/src/main/java/org/hillview/table/api/IIntColumn.java
@@ -44,7 +44,7 @@ public interface IIntColumn extends IColumn {
     default IndexComparator getComparator() {
         return new IndexComparator() {
             @Override
-            public int compare(final Integer i, final Integer j) {
+            public int compare(final int i, final int j) {
                 final boolean iMissing = IIntColumn.this.isMissing(i);
                 final boolean jMissing = IIntColumn.this.isMissing(j);
                 if (iMissing && jMissing) {

--- a/platform/src/main/java/org/hillview/table/api/IStringColumn.java
+++ b/platform/src/main/java/org/hillview/table/api/IStringColumn.java
@@ -43,7 +43,7 @@ public interface IStringColumn extends IColumn {
     default IndexComparator getComparator() {
         return new IndexComparator() {
             @Override
-            public int compare(final Integer i, final Integer j) {
+            public int compare(final int i, final int j) {
                 final boolean iMissing = IStringColumn.this.isMissing(i);
                 final boolean jMissing = IStringColumn.this.isMissing(j);
                 if (iMissing && jMissing) {

--- a/platform/src/main/java/org/hillview/table/api/IndexComparator.java
+++ b/platform/src/main/java/org/hillview/table/api/IndexComparator.java
@@ -17,7 +17,7 @@
 
 package org.hillview.table.api;
 
-import java.util.Comparator;
+import it.unimi.dsi.fastutil.ints.IntComparator;
 
 /**
  * A comparator which compares two values given by their integer indexes in an array/column/table.
@@ -25,14 +25,14 @@ import java.util.Comparator;
  * descending order. Missing values are treated as + infinity and appear at the very end of the
  * ascending order. The default implementations are in IIntColumn etc.
  */
-public abstract class IndexComparator implements Comparator<Integer> {
+public abstract class IndexComparator implements IntComparator {
     /**
      * The reverse comparator.
      */
     public IndexComparator rev() {
         return new IndexComparator() {
             @Override
-            public int compare(final Integer o1, final Integer o2) {
+            public int compare(final int o1, final int o2) {
                 return IndexComparator.this.compare(o2, o1);
             }
         };

--- a/platform/src/main/java/org/hillview/table/columns/ObjectArrayColumn.java
+++ b/platform/src/main/java/org/hillview/table/columns/ObjectArrayColumn.java
@@ -77,7 +77,7 @@ public final class ObjectArrayColumn extends BaseArrayColumn {
     public IndexComparator getComparator() {
         return new IndexComparator() {
             @Override
-            public int compare(final Integer i, final Integer j) {
+            public int compare(final int i, final int j) {
                 final boolean iMissing = ObjectArrayColumn.this.isMissing(i);
                 final boolean jMissing = ObjectArrayColumn.this.isMissing(j);
                 if (iMissing && jMissing) {

--- a/platform/src/main/java/org/hillview/table/columns/SparseColumn.java
+++ b/platform/src/main/java/org/hillview/table/columns/SparseColumn.java
@@ -83,7 +83,7 @@ public class SparseColumn extends BaseColumn
         return new IndexComparator() {
             @SuppressWarnings("ConstantConditions")
             @Override
-            public int compare(Integer o1, Integer o2) {
+            public int compare(int o1, int o2) {
             boolean o1m = SparseColumn.this.isMissing(o1);
             boolean o2m = SparseColumn.this.isMissing(o2);
             if (o1m) {

--- a/platform/src/test/java/org/hillview/test/ListComparatorTest.java
+++ b/platform/src/test/java/org/hillview/test/ListComparatorTest.java
@@ -38,7 +38,7 @@ public class ListComparatorTest extends BaseTest {
         final ColumnDescription desc2 = new ColumnDescription("test", ContentsKind.String, false);
         final IntArrayColumn col1 = new IntArrayColumn(desc1, size);
         final StringArrayColumn col2 = new StringArrayColumn(desc2, size);
-        final List<IndexComparator> listCompare = new ArrayList<IndexComparator>();
+        final ArrayList<IndexComparator> listCompare = new ArrayList<IndexComparator>();
         listCompare.add(col1.getComparator());
         listCompare.add(col2.getComparator().rev());
         final ListComparator listComp;
@@ -66,7 +66,7 @@ public class ListComparatorTest extends BaseTest {
         final Randomness rn = new Randomness();
         final ColumnDescription desc = new ColumnDescription("test", ContentsKind.Integer, false);
         final ArrayList<IColumn> cols = new ArrayList<IColumn>(numCols);
-        final List<IndexComparator> listCompare = new ArrayList<IndexComparator>();
+        final ArrayList<IndexComparator> listCompare = new ArrayList<IndexComparator>();
         for(int i = 0; i < numCols; i++) {
             final IntArrayColumn newCol = new IntArrayColumn(desc, size);
             for (int j = 0; j < size; j++) {

--- a/platform/src/test/java/org/hillview/test/MonoidTopKTest.java
+++ b/platform/src/test/java/org/hillview/test/MonoidTopKTest.java
@@ -18,7 +18,7 @@
 package org.hillview.test;
 
 import org.hillview.sketches.MonoidTopK;
-import org.hillview.sketches.TreeTopK;
+import org.hillview.sketches.IntTreeTopK;
 import org.hillview.utils.Converters;
 import org.hillview.utils.Randomness;
 import org.junit.Test;
@@ -49,8 +49,8 @@ public class MonoidTopKTest extends BaseTest {
     public void MonoidTopKTest0() {
         this.lSize = 100;
         this.rSize = 100;
-        TreeTopK<Integer> leftTree = new TreeTopK<Integer>(this.lSize, Integer::compare);
-        TreeTopK<Integer> rightTree = new TreeTopK<Integer>(this.rSize, Integer::compare);
+        IntTreeTopK leftTree = new IntTreeTopK(this.lSize, Integer::compare);
+        IntTreeTopK rightTree = new IntTreeTopK(this.rSize, Integer::compare);
         final Randomness rn = new Randomness();
         for (int i = 0; i < this.inpSize; i++)
             leftTree.push(rn.nextInt(this.inpSize));
@@ -66,8 +66,8 @@ public class MonoidTopKTest extends BaseTest {
     public void MonoidTopKTest1() {
         this.lSize = 50;
         this.rSize = 50;
-        TreeTopK<Integer> leftTree = new TreeTopK<Integer>(this.lSize, Integer::compare);
-        TreeTopK<Integer> rightTree = new TreeTopK<Integer>(this.rSize, Integer::compare);
+        IntTreeTopK leftTree = new IntTreeTopK(this.lSize, Integer::compare);
+        IntTreeTopK rightTree = new IntTreeTopK(this.rSize, Integer::compare);
         final Randomness rn = new Randomness();
         for (int i = 0; i < this.inpSize; i++)
             leftTree.push(rn.nextInt(this.inpSize));
@@ -83,8 +83,8 @@ public class MonoidTopKTest extends BaseTest {
     public void MonoidTopKTestTimed() {
         this.lSize = 1000;
         this.rSize = 1000;
-        TreeTopK<Integer> leftTree = new TreeTopK<Integer>(this.lSize, Integer::compare);
-        TreeTopK<Integer> rightTree = new TreeTopK<Integer>(this.rSize, Integer::compare);
+        IntTreeTopK leftTree = new IntTreeTopK(this.lSize, Integer::compare);
+        IntTreeTopK rightTree = new IntTreeTopK(this.rSize, Integer::compare);
         final Randomness rn = new Randomness();
         for (int i = 0; i < this.inpSize; i++)
             leftTree.push(rn.nextInt(this.inpSize));

--- a/platform/src/test/java/org/hillview/test/TreeTopKTest.java
+++ b/platform/src/test/java/org/hillview/test/TreeTopKTest.java
@@ -16,7 +16,7 @@
  */
 
 package org.hillview.test;
-import org.hillview.sketches.TreeTopK;
+import org.hillview.sketches.IntTreeTopK;
 import org.hillview.utils.Randomness;
 import org.junit.Test;
 
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class TreeTopKTest extends BaseTest {
     private final int maxSize = 10;
     public final int inpSize = 1000;
-    private final TreeTopK<Integer> myTree = new TreeTopK<Integer>(this.maxSize, Integer::compare);
+    private final IntTreeTopK myTree = new IntTreeTopK(this.maxSize, Integer::compare);
 
     @Test
     public void testHeapTopKZero() {

--- a/platform/src/test/java/org/hillview/test/TreeVsHeapTest.java
+++ b/platform/src/test/java/org/hillview/test/TreeVsHeapTest.java
@@ -18,7 +18,7 @@
 package org.hillview.test;
 
 import org.hillview.sketches.HeapTopK;
-import org.hillview.sketches.TreeTopK;
+import org.hillview.sketches.IntTreeTopK;
 import org.hillview.utils.Randomness;
 import org.junit.Test;
 
@@ -44,7 +44,7 @@ public class TreeVsHeapTest extends BaseTest {
             }
             endTime = System.nanoTime();
             PerfRegressionTest.comparePerf(" Using Heap: ", endTime - startTime);
-            final TreeTopK<Integer> myTree = new TreeTopK<Integer>(maxSize, Integer::compare);
+            final IntTreeTopK myTree = new IntTreeTopK(maxSize, Integer::compare);
             startTime = System.nanoTime();
             for (final int j: this.randInp) {
                 myTree.push(j);


### PR DESCRIPTION
Reduces allocations in the TopK implementations and NextKSketch. Given that all uses of `TreeTopK<T>` were with `TreeTopK<Integer>`, I added a specialized version `IntTreeTopK`. Allocations all in all were reduced from about 115MB -> ~600KB per TopK against 6.6M records.