### PR TITLE
Smart buckets

### DIFF
--- a/web/src/main/webapp/dataViews/histogramViewBase.ts
+++ b/web/src/main/webapp/dataViews/histogramViewBase.ts
@@ -217,7 +217,8 @@ export abstract class HistogramViewBase extends BigTableView {
 
         if (columnKind == "Integer" ||
             columnKind == "Category")
-            bucketCount = Math.min(bucketCount, stats.max - stats.min);
+            bucketCount = (stats.max - stats.min) / Math.ceil( (stats.max - stats.min) / maxBucketCount);
+
 
         return Math.floor(bucketCount);
     }

--- a/web/src/main/webapp/dataViews/histogramViewBase.ts
+++ b/web/src/main/webapp/dataViews/histogramViewBase.ts
@@ -219,7 +219,6 @@ export abstract class HistogramViewBase extends BigTableView {
             columnKind == "Category")
             bucketCount = (stats.max - stats.min) / Math.ceil( (stats.max - stats.min) / maxBucketCount);
 
-
         return Math.floor(bucketCount);
     }
 


### PR DESCRIPTION
Will choose a number of buckets that would minimize bucketing effects. Note that this is true for all histograms. So in two dimensional histograms if one access has (say) a range of 44 and 40 is the maximum number of colors allowed, then it would choose 22 colors, each with two values. 