### PR TITLE
Remove apache tomact tar.gz after extract

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -3,6 +3,7 @@
 
 # Bail out at first error
 set -e
+set -x
 
 mydir="$(dirname "$0")"
 if [[ ! -d "$mydir" ]]; then mydir="$PWD"; fi
@@ -22,6 +23,7 @@ if [ ! -d apache-tomcat-${TOMCATVERSION} ]; then
     rm -rf ROOT*
     ln -s ../../web/target/web-1.0-SNAPSHOT.war ROOT.war
     popd
+    rm -rf apache-tomcat-${TOMCATVERSION}.tar.gz
 else
     echo "Tomcat already installed"
 fi


### PR DESCRIPTION
set -x enables a mode of the shell where all executed commands are printed to the terminal. Printing every command as it is executed may help to visualize the control flow of the script if it is not functioning as expected.