### PR TITLE
Prevent '[WARNING] Using platform encoding (UTF-8 actually)'

### DIFF
--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -4,6 +4,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.hillview</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -1,6 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.hillview</groupId>
     <artifactId>web</artifactId>


### PR DESCRIPTION
Prevent the warnings while building web and platform.