### PR TITLE
Ignore the empty lines instead of halting with 'Could not parse line'

### DIFF
--- a/platform/src/main/java/org/hillview/storage/HillviewLogs.java
+++ b/platform/src/main/java/org/hillview/storage/HillviewLogs.java
@@ -81,6 +81,8 @@ public class HillviewLogs {
                     String line = reader.readLine();
                     if (line == null)
                         break;
+                    if (line.trim().isEmpty())
+                        continue;
                     this.parse(line, fields);
                     this.append(fields);
                 }


### PR DESCRIPTION
Ignore the empty lines.