### PR TITLE
Handle the java.net.ConnectException: Connection refused exception

### DIFF
--- a/bin/stop.py
+++ b/bin/stop.py
@@ -11,20 +11,21 @@ def stop_webserver(config):
     """Stops the Hillview web server"""
     assert isinstance(config, ClusterConfiguration)
     rh = config.get_webserver()
-    print("Stopping web server", rh)
-    rh.run_remote_shell_command(
-        config.service_folder + "/" + config.tomcat + "/bin/shutdown.sh")
+    print("Stopping web server on", rh)
+    rh.run_remote_shell_command("if pgrep -f tomcat; then " + config.service_folder + "/" +
+                                config.tomcat + "/bin/shutdown.sh; echo Stopped; else " +
+                                " echo \"Web server already stopped on " + str(rh.host) +"\"; " +
+                                " true; fi")
     rh.run_remote_shell_command(
         # The true is there to ignore the exit code of pkill
         "pkill -f Bootstrap; true")
 
 def stop_worker(rh):
     """Stops a Hillview service on a remote worker machine"""
-    print("Stopping", rh.host)
-    rh.run_remote_shell_command(
-        # The true is there to ignore the exit code of pkill
-        "pkill -f hillview-server; true")
-
+    print("Stopping hillview on ", rh.host)
+    rh.run_remote_shell_command("if pgrep -f hillview-server; then pkill -f hillview-server; true; " +
+                                "echo Stopped ; else echo \"Hillview already stopped on " +
+                                str(rh.host) +"\"; true; fi")
 def stop_backends(config):
     """Stops all Hillview workers"""
     assert isinstance(config, ClusterConfiguration)


### PR DESCRIPTION
If the user runs the stop.py when tomcat is not running, will encounter the following exception

root@hillview-root:~/DEPLOY-HILLVIEW/hillview/bin# python3 stop.py config.json
Importing configuration from config.json
Stopping web server hillview-root
On hillview-root : /root/hillview/apache-tomcat-9.0.4/bin/shutdown.sh
Oct 03, 2018 1:35:09 AM org.apache.catalina.startup.Catalina stopServer
SEVERE: Could not contact [localhost:[8005]]. Tomcat may not be running.
Oct 03, 2018 1:35:09 AM org.apache.catalina.startup.Catalina stopServer
SEVERE: Catalina.stop:
java.net.ConnectException: Connection refused (Connection refused)
        at java.net.PlainSocketImpl.socketConnect(Native Method)
        at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
        at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
        at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
        at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
        at java.net.Socket.connect(Socket.java:589)
        at java.net.Socket.connect(Socket.java:538)
        at java.net.Socket.<init>(Socket.java:434)
        at java.net.Socket.<init>(Socket.java:211)
        at org.apache.catalina.startup.Catalina.stopServer(Catalina.java:492)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.catalina.startup.Bootstrap.stopServer(Bootstrap.java:406)
        at org.apache.catalina.startup.Bootstrap.main(Bootstrap.java:495)

It would be good to handle this.