### PR TITLE
Display invalid hostname with reason instead of '?'

### DIFF
--- a/platform/src/main/java/org/hillview/utils/Utilities.java
+++ b/platform/src/main/java/org/hillview/utils/Utilities.java
@@ -134,8 +134,8 @@ public class Utilities {
             java.net.InetAddress localMachine = java.net.InetAddress.getLocalHost();
             return localMachine.getHostName();
         } catch (java.net.UnknownHostException e) {
-            HillviewLogger.instance.error("Cannot get host name");
-            return "?";
+            HillviewLogger.instance.error("Cannot get host name", e);
+            return e.getLocalizedMessage();
         }
     }
 


### PR DESCRIPTION
Current:  hillview-leaf-2, ?
With Fix: hillview-leaf-2, hillview-leaf-1: hillview-leaf-1: Name or service not known

Also, dump the cause in the logs.