### PR TITLE
Use $() notation instead of legacy backticked

### DIFF
--- a/bin/force-gc.sh
+++ b/bin/force-gc.sh
@@ -2,6 +2,5 @@
 # Simple shell script which tries to force a Java process to execute GC
 
 set -ex
-PID=`jcmd | grep hillview-server | awk '{print $1}'`
+PID=$(jcmd | grep hillview-server | awk '{print $1}')
 jcmd $PID GC.run
-


### PR DESCRIPTION
SC2006