### PR TITLE
Make the directory optional to exist in all the worker nodes

### DIFF
--- a/platform/src/main/java/org/hillview/maps/FindFilesMapper.java
+++ b/platform/src/main/java/org/hillview/maps/FindFilesMapper.java
@@ -62,9 +62,12 @@ public class FindFilesMapper implements IMap<Empty, List<IFileReference>> {
 
         Stream<Path> files;
         try {
-            files = Files.walk(dir, 1, FileVisitOption.FOLLOW_LINKS);
+            if(Files.exists(dir))
+                files = Files.walk(dir, 1, FileVisitOption.FOLLOW_LINKS);
+            else
+                return Collections.emptyList();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException(e); 
         }
         files = files.filter(f -> {
             if (f == null)


### PR DESCRIPTION
Now if atleast single worker node contains a directory it will show the output for that file and not show the  RunTimeException which was shown earlier.