### PR TITLE
Integrate console logging instead of simple prints

### DIFF
--- a/bin/delete-data.py
+++ b/bin/delete-data.py
@@ -6,6 +6,9 @@
 import os.path
 from argparse import ArgumentParser
 from hillviewCommon import ClusterConfiguration, get_config
+from hillviewConsoleLog import get_logger
+
+logger = get_logger("delete-data")
 
 def delete_remote_folder(rh, folder):
     """Deletes folder on the remote host"""
@@ -17,7 +20,8 @@ def delete_remote_folder(rh, folder):
 def delete_folder(config, folder):
     """Delete a folder on all remote hosts"""
     assert isinstance(config, ClusterConfiguration)
-    print("Deleting", folder, "from all hosts")
+    message = "Deleting " + folder + " from all hosts"
+    logger.info(message)
     config.run_on_all_workers(lambda rh: delete_remote_folder(rh, folder), True)
 
 def main():
@@ -31,7 +35,7 @@ def main():
     if not os.path.isabs(folder):
         folder = os.path.join(config.service_folder, folder)
     delete_folder(config, folder)
-    print("Done")
+    logger.info("Done")
 
 if __name__ == "__main__":
     main()

--- a/bin/deploy.py
+++ b/bin/deploy.py
@@ -8,13 +8,17 @@ from argparse import ArgumentParser
 import tempfile
 import os.path
 from hillviewCommon import ClusterConfiguration, get_config
+from hillviewConsoleLog import get_logger
+
+logger = get_logger("deploy")
 
 def prepare_webserver(config):
     """Deploys files needed by the Hillview web server"""
-    print("Creating web service folder")
+    logger.info("Creating web service folder")
     assert isinstance(config, ClusterConfiguration)
     rh = config.get_webserver()
-    print("Preparing web server", rh)
+    message = "Preparing web server " + str(rh)
+    logger.info(message)
     rh.create_remote_folder(config.service_folder)
     rh.run_remote_shell_command("chown " + config.get_user() + " " + config.service_folder)
     rh.create_remote_folder(config.service_folder + "/hillview")
@@ -57,8 +61,9 @@ def prepare_webserver(config):
 def prepare_worker(config, rh):
     """Prepares files needed by a Hillview worker on a remote machine"""
     assert isinstance(config, ClusterConfiguration)
-    print("Preparing worker", rh)
-#    rh.run_remote_shell_command("sudo apt-get install libgfortran3")
+    message = "Preparing worker " + str(rh)
+    logger.info(message)
+    # rh.run_remote_shell_command("sudo apt-get install libgfortran3")
     rh.create_remote_folder(config.service_folder)
     rh.run_remote_shell_command("chown " + config.get_user() + " " + config.service_folder)
     rh.create_remote_folder(config.service_folder + "/hillview")
@@ -74,7 +79,8 @@ def prepare_worker(config, rh):
 def prepare_aggregator(config, rh):
     """Prepares files needed by a Hillview aggregator on a remote machine"""
     assert isinstance(config, ClusterConfiguration)
-    print("Preparing aggregator", rh)
+    message = "Preparing aggregator " + str(rh)
+    logger.info(message)
     rh.create_remote_folder(config.service_folder)
     rh.run_remote_shell_command("chown " + config.get_user() + " " + config.service_folder)
     rh.create_remote_folder(config.service_folder + "/hillview")

--- a/bin/download-data.py
+++ b/bin/download-data.py
@@ -10,6 +10,9 @@ import os.path
 import os
 import errno
 from hillviewCommon import execute_command, ClusterConfiguration, get_config
+from hillviewConsoleLog import get_logger
+
+logger = get_logger("download-data")
 
 def copy_from_remote_host(rh, pattern):
     """Copy files matching the pattern from the remote machine"""
@@ -24,6 +27,8 @@ def copy_from_remote_host(rh, pattern):
     else:
         u = rh.user + "@"
     command = "scp -r " + u + rh.host + ":" + pattern + " " + rh.host
+    message = "Copying the files from the remote machine " + str(rh.host)
+    logger.info(message)
     execute_command(command)
 
 def copy_files(config, pattern):
@@ -40,7 +45,7 @@ def main():
     config = get_config(parser, args)
     pattern = args.pattern
     copy_files(config, pattern)
-    print("Done.")
+    logger.info("Done.")
 
 if __name__ == "__main__":
     main()

--- a/bin/hillviewCommon.py
+++ b/bin/hillviewCommon.py
@@ -6,13 +6,17 @@ import subprocess
 import tempfile
 import json
 from argparse import ArgumentParser
+from hillviewConsoleLog import get_logger
+
+logger = get_logger("hillviewCommon")
 
 def execute_command(command):
     """Executes the specified command using a shell"""
-    print(command)
+    logger.info(command)
     exitcode = subprocess.call(command, shell=True)
     if exitcode != 0:
-        print("Exit code returned:", exitcode)
+        error = "Exit code returned:" + str(exitcode)
+        logger.error(error)
         exit(exitcode)
 
 class RemoteHost:
@@ -42,13 +46,15 @@ class RemoteHost:
         f = open(file.name)
         text = f.read()
         if verbose:
-            print("On", self.host, ":", text)
+            message = "On " + str(self.host) + ": " + text
+            logger.info(message)
         f.close()
 
         command = "ssh " + self.uh() + " bash -s < " + file.name
         exitcode = subprocess.call(command, shell=True)
         if exitcode != 0:
-            print("Exit code returned:", exitcode)
+            error = "Exit code returned: " + str(exitcode)
+            logger.error(error)
             exit(exitcode)
         os.unlink(file.name)
 
@@ -106,20 +112,24 @@ class ClusterConfiguration:
 
     def __init__(self, file):
         """Load the configuration file describing the Hillview deployment."""
-        print("Reading cluster configuration from", file)
+        message = "Reading cluster configuration from " + file
+        logger.info(message)
         if not os.path.exists(file):
-            print("Configuration file `" + file + "' does not exist")
+            error = "Configuration file '" + file + "' does not exist"
+            logger.info(error)
             exit(1)
         try:
             with open(file) as contents:
                 stripped = "".join(line.partition("//")[0] for line in contents)
             self.jsonConfig = json.loads(stripped, object_hook=JsonConfig)
         except:
-            print("Error parsing configuration file", file)
+            error = "Error parsing configuration file " + file
+            logger.error(error)
             exit(1)
         if not os.path.isabs(self.jsonConfig.service_folder):
-            print("service_folder must be an absolute path in configuration file",
-                  self.jsonConfig.service_folder)
+            error = "service_folder must be an absolute path in configuration file " + \
+                    self.jsonConfig.service_folder
+            logger.error(error)
             exit(1)
         # The path where the current script is installed
         self.scriptFolder = os.path.dirname(os.path.abspath(__file__))

--- a/bin/hillviewConsoleLog.py
+++ b/bin/hillviewConsoleLog.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""
+This module defines a function which implement a
+flexible event logging system for the hillview
+"""
+# pylint: disable=invalid-name
+
+import logging
+
+def get_logger(module_name):
+    """ Returns the logger object """
+    logger = logging.getLogger(module_name)
+    logger.setLevel(logging.DEBUG)
+    con_log_handler = logging.StreamHandler()
+    con_log_handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    con_log_handler.setFormatter(formatter)
+    logger.addHandler(con_log_handler)
+    return logger

--- a/bin/run-on-all.py
+++ b/bin/run-on-all.py
@@ -6,11 +6,15 @@
 
 from argparse import ArgumentParser, REMAINDER
 from hillviewCommon import ClusterConfiguration, get_config
+from hillviewConsoleLog import get_logger
+
+logger = get_logger("run-on-all")
 
 def execute_command_on_all(config, command, parallel):
     """Executes command on all workers"""
     assert isinstance(config, ClusterConfiguration)
-    print("Executing `", command, "' on", len(config.get_workers()), "hosts")
+    message = "Executing `" + str(command) + "' on " + str(len(config.get_workers())) + " hosts"
+    logger.info(message)
     lam = lambda rh: rh.run_remote_shell_command(command)
     config.run_on_all_workers(lam, parallel)
 

--- a/bin/start.py
+++ b/bin/start.py
@@ -6,12 +6,16 @@
 
 from argparse import ArgumentParser
 from hillviewCommon import RemoteHost, RemoteAggregator, ClusterConfiguration, get_config
+from hillviewConsoleLog import get_logger
+
+logger = get_logger("start")
 
 def start_webserver(config):
     """Starts the Hillview web server"""
     assert isinstance(config, ClusterConfiguration)
     rh = config.get_webserver()
-    print("Starting web server", rh)
+    message = "Starting web server " + str(rh)
+    logger.info(message)
     rh.run_remote_shell_command(
         "export WEB_CLUSTER_DESCRIPTOR=serverlist; cd " + config.service_folder + "; nohup " + \
         config.tomcat + "/bin/startup.sh &")
@@ -20,7 +24,8 @@ def start_worker(config, rh):
     """Starts the Hillview worker on a remote machine"""
     assert isinstance(rh, RemoteHost)
     assert isinstance(config, ClusterConfiguration)
-    print("Starting worker", rh)
+    message = "Starting worker " + str(rh)
+    logger.info(message)
     gclog = config.service_folder + "/hillview/gc.log"
     rh.run_remote_shell_command(
         "cd " + config.service_folder + "/hillview; " + \
@@ -34,7 +39,8 @@ def start_aggregator(config, agg):
     """Starts a Hillview aggregator"""
     assert isinstance(agg, RemoteAggregator)
     assert isinstance(config, ClusterConfiguration)
-    print("Starting aggregator", agg)
+    message = "Starting aggregator " + str(agg)
+    logger.info(message)
     agg.run_remote_shell_command(
         "cd " + config.service_folder + "/hillview; " + \
         "nohup java -Dlog4j.configurationFile=./log4j.properties -server " + \

--- a/bin/status.py
+++ b/bin/status.py
@@ -6,11 +6,16 @@
 
 from argparse import ArgumentParser
 from hillviewCommon import ClusterConfiguration, RemoteHost, get_config
+from hillviewConsoleLog import get_logger
+
+logger = get_logger("status")
 
 def check_webserver(config):
     """Checks if the Hillview web server is running"""
     assert isinstance(config, ClusterConfiguration)
     rh = config.get_webserver()
+    message = "Checking hillview status on " + str(rh)
+    logger.info(message)
     rh.run_remote_shell_command("if pgrep -f tomcat; then true; else " +
                                 " echo \"Web server not running on " + str(rh.host) +"\"; " +
                                 " false; fi")
@@ -19,6 +24,8 @@ def check_worker(config, rh):
     """Checks if the Hillview service is running on a remote machine"""
     assert isinstance(config, ClusterConfiguration)
     assert isinstance(rh, RemoteHost)
+    message = "Checking hillview status on " + str(rh.host)
+    logger.info(message)
     rh.run_remote_shell_command("if pgrep -f hillview-server; then true; else " +
                                 " echo \"Hillview not running on " + str(rh.host) +"\"; " +
                                 " cat " + config.service_folder + "/hillview/nohup.out; false; fi")

--- a/bin/stop.py
+++ b/bin/stop.py
@@ -6,12 +6,16 @@
 
 from argparse import ArgumentParser
 from hillviewCommon import ClusterConfiguration, get_config
+from hillviewConsoleLog import get_logger
+
+logger = get_logger("stop")
 
 def stop_webserver(config):
     """Stops the Hillview web server"""
     assert isinstance(config, ClusterConfiguration)
     rh = config.get_webserver()
-    print("Stopping web server on", rh)
+    message = "Stopping web server on " + str(rh)
+    logger.info(message)
     rh.run_remote_shell_command("if pgrep -f tomcat; then " + config.service_folder + "/" +
                                 config.tomcat + "/bin/shutdown.sh; echo Stopped; else " +
                                 " echo \"Web server already stopped on " + str(rh.host) +"\"; " +
@@ -22,7 +26,8 @@ def stop_webserver(config):
 
 def stop_worker(rh):
     """Stops a Hillview service on a remote worker machine"""
-    print("Stopping hillview on ", rh.host)
+    message = "Stopping hillview on " + str(rh.host)
+    logger.info(message)
     rh.run_remote_shell_command("if pgrep -f hillview-server; then pkill -f hillview-server; "+
                                 "true; echo Stopped ; else echo \"Hillview already stopped on " +
                                 str(rh.host) +"\"; true; fi")

--- a/bin/upload-data.py
+++ b/bin/upload-data.py
@@ -10,7 +10,9 @@
 from argparse import ArgumentParser, REMAINDER
 import os.path
 from hillviewCommon import ClusterConfiguration, get_config
+from hillviewConsoleLog import get_logger
 
+logger = get_logger("upload-data")
 created_folders = set()
 
 def create_remote_folder(remoteHost, folder):
@@ -29,13 +31,15 @@ def copy_file_to_remote_host(rh, source, folder, copyOption):
 def copy_everywhere(config, file, folder, copyOption):
     """Copy specified file to all worker machines"""
     assert isinstance(config, ClusterConfiguration)
-    print("Copying", file, "to all hosts")
+    message = "Copying " + file + " to all hosts"
+    logger.info(message)
     config.run_on_all_workers(lambda rh: copy_file_to_remote_host(rh, file, folder, copyOption))
 
 def copy_files(config, folder, filelist, copyOption):
     """Copy the files to the given machines in round-robin fashion"""
     assert isinstance(config, ClusterConfiguration)
-    print("Copying", len(filelist), "files to all hosts in round-robin")
+    message = "Copying " + str(len(filelist)) + " files to all hosts in round-robin"
+    logger.info(message)
     index = 0
     workers = config.get_workers()
     for f in filelist:
@@ -59,7 +63,7 @@ def main():
     config = get_config(parser, args)
     folder = args.directory
     if folder is None:
-        print("Directory argument is mandatory")
+        logger.error("Directory argument is mandatory")
         parser.print_help()
         exit(1)
     if args.symlinks:
@@ -68,14 +72,15 @@ def main():
         copyOptions = ""
     if not os.path.isabs(folder):
         folder = os.path.join(config.service_folder, folder)
-        print("Folder is relative, using", folder)
+        message = "Folder is relative, using " + folder
+        logger.info(message)
     if args.common is not None:
         copy_everywhere(config, args.common, folder, copyOptions)
     if args.files:
         copy_files(config, folder, args.files, copyOptions)
     else:
-        print("No files to upload to the machines provided in a Hillview configuration")
-    print("Done.")
+        logger.error("No files to upload to the machines provided in a Hillview configuration")
+    logger.info("Done.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
root@hillview-root:~/DEPLOY-HILLVIEW/hillview/bin# python3 start.py config.json

2018-11-02 04:14:12,085 - hillviewCommon - INFO - Reading cluster configuration from config.json
2018-11-02 04:14:12,086 - start - INFO - Starting web server hillview-root
2018-11-02 04:14:12,088 - hillviewCommon - INFO - On hillview-root: export WEB_CLUSTER_DESCRIPTOR=serverlist; cd /root/hillview; nohup apache-tomcat-9.0.4/bin/startup.sh &
Tomcat started.
2018-11-02 04:14:12,533 - start - INFO - Starting worker hillview-leaf-1
2018-11-02 04:14:12,535 - hillviewCommon - INFO - On hillview-leaf-1: cd /root/hillview/hillview; nohup java -Dlog4j.configurationFile=./log4j.properties -server  -Xmx4G -Xloggc:/root/hillview/hillview/gc.log -jar /root/hillview/hillview/hillview-server-jar-with-dependencies.jar 0.0.0.0:3569 >nohup.out 2>&1 &
2018-11-02 04:14:13,799 - start - INFO - Starting worker hillview-leaf-2
2018-11-02 04:14:13,801 - hillviewCommon - INFO - On hillview-leaf-2: cd /root/hillview/hillview; nohup java -Dlog4j.configurationFile=./log4j.properties -server  -Xmx4G -Xloggc:/root/hillview/hillview/gc.log -jar /root/hillview/hillview/hillview-server-jar-with-dependencies.jar 0.0.0.0:3569 >nohup.out 2>&1 &
