### PR TITLE
Implemented prune API for IDataSet

### DIFF
--- a/bin/config.json
+++ b/bin/config.json
@@ -1,5 +1,5 @@
-// This file is a Json file that defines the configuration for a
-// Hillview deployment.
+// This file is a sample Json file that defines the configuration for a
+// Hillview deployment.  Do not modify this file, make a copy instead.
 
 {
   // Name of machine hosting the web server

--- a/platform/src/main/java/org/hillview/dataset/api/IMap.java
+++ b/platform/src/main/java/org/hillview/dataset/api/IMap.java
@@ -17,6 +17,8 @@
 
 package org.hillview.dataset.api;
 
+import javax.annotation.Nullable;
+
 /**
  * A closure that runs a computation on an object of type T and returns an object of type S.
  * IMap objects have to be immutable once created.
@@ -29,5 +31,6 @@ public interface IMap<T, S> extends IDataSetComputation {
      * @param data Data to transform.
      * @return The result of the transformation.
      */
-    S apply(T data);
+    @Nullable
+    S apply(@Nullable T data);
 }

--- a/platform/src/main/java/org/hillview/dataset/api/ISketch.java
+++ b/platform/src/main/java/org/hillview/dataset/api/ISketch.java
@@ -18,6 +18,8 @@
 package org.hillview.dataset.api;
 import org.hillview.utils.Converters;
 
+import javax.annotation.Nullable;
+
 /**
  * Describes a sketch computation on a dataset of type T that produces a result of type R.
  * This class is also a monoid which knows how to combine two values of type R using the add
@@ -31,10 +33,12 @@ public interface ISketch<T, R> extends IDataSetComputation, IMonoid<R> {
      * @param data  Data to sketch.
      * @return  A sketch of the data.
      */
-    R create(T data);
+    @Nullable
+    R create(@Nullable T data);
 
     /**
      * Helper method to return non-null zeros.
      */
+    @Nullable
     default R getZero() { return Converters.checkNull(this.zero()); }
 }

--- a/platform/src/main/java/org/hillview/dataset/remoting/PruneOperation.java
+++ b/platform/src/main/java/org/hillview/dataset/remoting/PruneOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware Inc. All Rights Reserved.
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,9 +17,18 @@
 
 package org.hillview.dataset.remoting;
 
+import org.hillview.dataset.api.IMap;
+
 import java.io.Serializable;
 
 /**
- * Base type for remote operations with a unique ID
+ * Wrap an IMap object to be sent to a remote node for a prune operation.
+ * @param <T> Input type of the map function
  */
-public class RemoteOperation implements Serializable {}
+public class PruneOperation<T> extends RemoteOperation implements Serializable {
+    public final IMap<T, Boolean> isEmpty;
+
+    public PruneOperation(final IMap<T, Boolean> isEmpty) {
+        this.isEmpty = isEmpty;
+    }
+}

--- a/platform/src/main/java/org/hillview/main/DataUpload.java
+++ b/platform/src/main/java/org/hillview/main/DataUpload.java
@@ -62,7 +62,7 @@ public class DataUpload {
         String filename; // the file to be sent
         @Nullable
         String directory;
-        ArrayList<String> fileList = new ArrayList<String>();
+        final ArrayList<String> fileList = new ArrayList<String>();
         String remoteFolder = ""; // the destination path where the files will be put
         String cluster = ""; // the path to the cluster config json file
         boolean hasHeader; // true if file has a header row
@@ -400,7 +400,7 @@ public class DataUpload {
             if (err != 0)
                 throw new RuntimeException("Scp stopped with error code " + Integer.toString(err));
     }
-    
+
     /** Writes the table in ORC or CSV format
       */
     private static void writeTable(Table table, String filename, boolean orc) {

--- a/platform/src/main/java/org/hillview/maps/FalseMap.java
+++ b/platform/src/main/java/org/hillview/maps/FalseMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware Inc. All Rights Reserved.
+ * Copyright (c) 2018 VMware Inc. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,11 +15,18 @@
  * limitations under the License.
  */
 
-package org.hillview.dataset.remoting;
+package org.hillview.maps;
 
-import java.io.Serializable;
+import org.hillview.dataset.api.IMap;
+
+import javax.annotation.Nullable;
 
 /**
- * Base type for remote operations with a unique ID
+ * An IMap which always returns 'false'.  Useful for prune().
  */
-public class RemoteOperation implements Serializable {}
+public class FalseMap<T> implements IMap<T, Boolean> {
+    @Override
+    public Boolean apply(@Nullable T data) {
+        return false;
+    }
+}

--- a/platform/src/main/java/org/hillview/sketches/BucketsInfo.java
+++ b/platform/src/main/java/org/hillview/sketches/BucketsInfo.java
@@ -29,7 +29,7 @@ public abstract class BucketsInfo implements Serializable, IJson {
     public long presentCount;
     public long missingCount;
 
-    public BucketsInfo() {
+    protected BucketsInfo() {
         this.presentCount = 0;
         this.missingCount = 0;
     }

--- a/platform/src/main/java/org/hillview/sketches/DataRange.java
+++ b/platform/src/main/java/org/hillview/sketches/DataRange.java
@@ -20,8 +20,8 @@ package org.hillview.sketches;
 import org.hillview.dataset.api.IJson;
 
 public class DataRange extends BucketsInfo implements IJson {
-    public double min;
-    public double max;
+    double min;
+    double max;
 
     DataRange() {
         this.min = 0;

--- a/platform/src/main/java/org/hillview/sketches/DistinctStringsSketch.java
+++ b/platform/src/main/java/org/hillview/sketches/DistinctStringsSketch.java
@@ -44,7 +44,7 @@ public class DistinctStringsSketch implements ISketch<ITable, DistinctStringsSke
             this.uniqueStrings = hash;
         }
 
-        public void add(@Nullable String string) {
+        void add(@Nullable String string) {
             this.uniqueStrings.add(string);
         }
 
@@ -54,7 +54,7 @@ public class DistinctStringsSketch implements ISketch<ITable, DistinctStringsSke
          * @return the union of two sets. The maxSize is the larger of the two. If one
          * of them allow for unbounded size (maxSize = 0) then so does the union.
          */
-        public DistinctStrings union(final DistinctStrings otherSet) {
+        DistinctStrings union(final DistinctStrings otherSet) {
             ObjectOpenHashSet<String> hash = new ObjectOpenHashSet<String>(
                     Math.max(this.uniqueStrings.size(), otherSet.uniqueStrings.size()));
             hash.addAll(this.uniqueStrings);

--- a/platform/src/main/java/org/hillview/storage/GenericLogs.java
+++ b/platform/src/main/java/org/hillview/storage/GenericLogs.java
@@ -66,8 +66,8 @@ public class GenericLogs {
     }
 
     public class LogFileLoader extends TextFileLoader {
-        private Grok grok;
-        private GrokCompiler grokCompiler;
+        private final Grok grok;
+        private final GrokCompiler grokCompiler;
 
         @Nullable
         private final Instant start;
@@ -82,8 +82,8 @@ public class GenericLogs {
         private final Grok dateTime;
         @Nullable
         private List<String> columnNames = null;
-        private StringListColumn parsingErrors;
-        private IntListColumn lineNumber;
+        private final StringListColumn parsingErrors;
+        private final IntListColumn lineNumber;
 
         LogFileLoader(final String path, @Nullable Instant start, @Nullable Instant end) {
             super(path);

--- a/platform/src/main/java/org/hillview/table/columns/BaseListColumn.java
+++ b/platform/src/main/java/org/hillview/table/columns/BaseListColumn.java
@@ -36,7 +36,7 @@ public abstract class BaseListColumn extends BaseColumn implements IAppendableCo
     static final int SegmentMask = SegmentSize - 1;
 
     @Nullable
-    protected ArrayList<BitSet> missing = null;
+    ArrayList<BitSet> missing = null;
     int size;
 
     BaseListColumn(final ColumnDescription desc) {

--- a/platform/src/main/java/org/hillview/table/columns/ConstantStringColumn.java
+++ b/platform/src/main/java/org/hillview/table/columns/ConstantStringColumn.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
  * A ConstantStringColumn is a column where all values are identical.
  */
 public class ConstantStringColumn extends BaseColumn implements IStringColumn {
-    public final int size;
+    private final int size;
     @Nullable
     private final String value;
 

--- a/platform/src/main/proto/hillview.proto
+++ b/platform/src/main/proto/hillview.proto
@@ -13,6 +13,7 @@ service HillviewServer {
   rpc manage (Command) returns (stream PartialResponse) {}
   rpc zip (Command) returns (stream PartialResponse) {}
   rpc unsubscribe (Command) returns (Ack) {}
+  rpc prune (Command) returns (stream PartialResponse) {}
 }
 
 message Command

--- a/platform/src/test/java/org/hillview/test/TestUtil.java
+++ b/platform/src/test/java/org/hillview/test/TestUtil.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 public class TestUtil {
-    private static boolean silent = true;
+    private static final boolean silent = true;
 
     /**
      * Provides access to private members in classes for testing.

--- a/platform/src/test/java/org/hillview/test/dataStructures/ComputeTrellisShape.java
+++ b/platform/src/test/java/org/hillview/test/dataStructures/ComputeTrellisShape.java
@@ -27,8 +27,8 @@ class ComputeTrellisShape {
     private final int x_min;
     private final int y_max;
     private final int y_min;
-    private double max_ratio;
-    private int header_ht;
+    private final double max_ratio;
+    private final int header_ht;
     private final int max_width;
     private final int max_height;
 

--- a/platform/src/test/java/org/hillview/test/dataset/FindSketchTest.java
+++ b/platform/src/test/java/org/hillview/test/dataset/FindSketchTest.java
@@ -29,7 +29,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class FindSketchTest extends BaseTest {
-    boolean toPrint = false;
+    final boolean toPrint = false;
 
     @Test
     public void testFind1() {

--- a/platform/src/test/java/org/hillview/test/dataset/MinKTest.java
+++ b/platform/src/test/java/org/hillview/test/dataset/MinKTest.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class MinKTest {
-    private Boolean printOn = false;
+    private final Boolean printOn = false;
 
     private double getMaxErr(int suppSize, List<Integer> ranks) {
         int numBuckets = ranks.size() - 1;

--- a/platform/src/test/java/org/hillview/test/storage/GenericLogsTest.java
+++ b/platform/src/test/java/org/hillview/test/storage/GenericLogsTest.java
@@ -40,7 +40,7 @@ import java.util.List;
  * Various tests for reading Generic logs into ITable.
  */
 public class GenericLogsTest extends BaseTest {
-    private static boolean print = false;
+    private static final boolean print = false;
 
     @Test
     public void findTimestamp() {

--- a/web/src/main/java/org/hillview/targets/CorrelationMatrixTarget.java
+++ b/web/src/main/java/org/hillview/targets/CorrelationMatrixTarget.java
@@ -70,8 +70,8 @@ final class CorrelationMatrixTarget extends RpcTarget {
         }
 
         public String toString() {
-            return Arrays.toString(this.eigenValues) + "\n Total Variance: "+ String.valueOf(totalVar) +
-                    "\n Explained Variance: "+ String.valueOf(explainedVar) ;
+            return Arrays.toString(this.eigenValues) + "\n Total Variance: "+ totalVar +
+                    "\n Explained Variance: "+ explainedVar;
         }
     }
 

--- a/web/src/main/java/org/hillview/targets/FileDescriptionTarget.java
+++ b/web/src/main/java/org/hillview/targets/FileDescriptionTarget.java
@@ -20,6 +20,7 @@ package org.hillview.targets;
 import org.hillview.*;
 import org.hillview.dataset.api.IDataSet;
 import org.hillview.dataset.api.IMap;
+import org.hillview.maps.FalseMap;
 import org.hillview.maps.LoadFilesMapper;
 import org.hillview.sketches.FileSizeSketch;
 import org.hillview.storage.IFileReference;
@@ -49,6 +50,11 @@ public class FileDescriptionTarget extends RpcTarget {
     public void loadTable(RpcRequest request, RpcRequestContext context) {
         IMap<IFileReference, ITable> loader = new LoadFilesMapper();
         this.runMap(this.files, loader, TableTarget::new, request, context);
+    }
+
+    @HillviewRpc
+    public void prune(RpcRequest request, RpcRequestContext context) {
+        this.runPrune(this.files, new FalseMap<IFileReference>(), FileDescriptionTarget::new, request, context);
     }
 }
 

--- a/web/src/main/webapp/ui/editBox.ts
+++ b/web/src/main/webapp/ui/editBox.ts
@@ -73,7 +73,7 @@ export class EditBox implements IHtmlElement {
         this.textArea.value = value;
     }
 
-    public setTabIndex(index: number) {
+    public setTabIndex(index: number): void {
         this.topLevel.tabIndex = index;
     }
 

--- a/web/src/main/webapp/ui/progress.ts
+++ b/web/src/main/webapp/ui/progress.ts
@@ -164,14 +164,14 @@ export class ProgressManager implements IHtmlElement {
         return this.topLevel;
     }
 
-    public newProgressBar(operation: IRawCancellable, description: string) {
+    public newProgressBar(operation: IRawCancellable, description: string): ProgressBar {
         this.topLevel.classList.remove("idle");
         const p = new ProgressBar(this, description, operation);
         this.topLevel.appendChild(p.getHTMLRepresentation());
         return p;
     }
 
-    public removeProgressBar(p: ProgressBar) {
+    public removeProgressBar(p: ProgressBar): void {
         this.topLevel.removeChild(p.getHTMLRepresentation());
         if (this.topLevel.children.length === 0)
             this.topLevel.classList.add("idle");

--- a/web/src/main/webapp/ui/scroll.ts
+++ b/web/src/main/webapp/ui/scroll.ts
@@ -63,7 +63,7 @@ export class ScrollBar implements IHtmlElement {
     private height: number;
     private readonly target: IScrollTarget;
 
-    private heightAttr: string;
+    private readonly heightAttr: string;
     private widthAttr: string;
     private xAttr: string;
     private yAttr: string;

--- a/web/src/main/webapp/ui/selectionStateMachine.ts
+++ b/web/src/main/webapp/ui/selectionStateMachine.ts
@@ -40,7 +40,7 @@ export class SelectionStateMachine {
         this.excluded = new Set<number>();
     }
 
-    public exclude(val: number) {
+    public exclude(val: number): void {
         this.excluded.add(val);
         this.delete(val);
     }
@@ -57,24 +57,24 @@ export class SelectionStateMachine {
         return this.selected.has(val);
     }
 
-    public clear() {
+    public clear(): void {
         this.selected.clear();
         this.curState = null;
     }
 
-    private toggle(val: number) {
+    private toggle(val: number): void {
         if (this.has(val))
             this.delete(val);
         else
             this.add(val);
     }
 
-    public add(val: number) {
+    public add(val: number): void {
         if (!this.excluded.has(val))
             this.selected.add(val);
     }
 
-    public delete(val: number) {
+    public delete(val: number): void {
         this.selected.delete(val);
     }
 
@@ -82,7 +82,7 @@ export class SelectionStateMachine {
      * Changes the membership for all states in the interval [a,b] to the boolean value to.
      * Is used when the shift key is pressed.
      */
-    private rangeChange(a: number, b: number, to: boolean) {
+    private rangeChange(a: number, b: number, to: boolean): void {
         for (let i = a; i <= b; i++) {
             if (to)
                 this.add(i);
@@ -102,7 +102,7 @@ export class SelectionStateMachine {
      * - Type Shift: Toggle the state of val. Change the state of the open interval from the last clicked state to val,
      * so that its state matches that of val.
      */
-    public changeState(type: TransitionType, val: number) {
+    public changeState(type: TransitionType, val: number): void {
         if (type === "NoKey") { // No buttons pressed, forget everything else, toggle val
             const isPresent: boolean = this.has(val);
             this.selected.clear();


### PR DESCRIPTION
@arvind008 @SivaMaplelabs : the addition of the prune() operator for IDataSet is meant to support some scenarios you are interested in: multiple simultaneous deployments on the same cluster which span different machines. 

prune is a very general tool; the way it is used at this point is the following: after finding the files to load, prune is called. This will exclude from the cluster all machines that do not have any matching files. So the front-end will communicate only with the "useful" machines from now on. So only the first few messages involve the whole cluster.

I will merge this PR, but feel free to take a look.

I also did some code refactoring to eliminate code duplication.