### PR TITLE
install-dependencies.sh: Add support for Debian.

### DIFF
--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -11,7 +11,7 @@ TOMCATVERSION="9.0.4"
 
 case "$OSTYPE" in
     linux*)
-        if [ "$(cat /etc/*-release | grep -c ubuntu)" -ne 0 ]; then
+        if [ "$(cat /etc/*-release | grep -Ec 'ubuntu|debian')" -ne 0 ]; then
 	        # Npm will be installed with node.js
 	    	INSTALL="apt-get"; SUDO="sudo"; NODEJS="nodejs"; NPM="";
 	    elif [ "$(cat /etc/*-release | grep -c -e centos -e rhel )" -ne 0 ]; then


### PR DESCRIPTION
Debian and Ubuntu are similar and, once I made this small change, the
install went fine for me on Debian.