### PR TITLE
Use a JSON editor to edit the privacy metadata

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -19,9 +19,9 @@ case "$OSTYPE" in
 	curl -sL https://deb.nodesource.com/setup_11.x | ${SUDO} -E bash -
 esac
 
-${SUDO} ${INSTALL}  install wget maven ${NODEJS} ${NPM} ${LIBFORTRAN} unzip gzip
+${SUDO} ${INSTALL} install wget maven ${NODEJS} ${NPM} ${LIBFORTRAN} unzip gzip
 echo "Installing typescript compiler"
-${SUDO} npm install -g typescript@3.1.5
+${SUDO} npm install -g typescript@3.7
 
 cd ..
 if [ ! -d apache-tomcat-${TOMCATVERSION} ]; then

--- a/data/ontime_private/gen_metadata.py
+++ b/data/ontime_private/gen_metadata.py
@@ -33,15 +33,12 @@ def get_metadata(cn):
             'globalMax': gMax}
 
 def get_string_metadata(col):
-    letters = list(string.ascii_uppercase) + list(string.ascii_lowercase)
+    letters = list(string.ascii_uppercase)
     if col == "OriginState" or col == "DestState":
         letters = states
     return {'type': "StringColumnQuantization",
-            'globalMax': 'z',
+            'globalMax': 'a',
             'leftBoundaries': letters }
-
-def concat_colnames(colnames):
-    return '+'.join(colnames)
 
 def main():
     colnames = []
@@ -55,18 +52,14 @@ def main():
 
     with open('privacy_metadata.json', 'w') as f:
         quantization = {}
-        epsilons = {}
+        defaultEpsilons = { "1": 1, "2": .1 }
         for col in schema:
             cn = col["name"]
             if col["kind"] == "String":
                 quantization[cn] = get_string_metadata(cn)
             else:
                 quantization[cn] = get_metadata(cn)
-            epsilons[cn] = 1
-        for cn in length2:
-            concat_cn = concat_colnames(cn)
-            epsilons[concat_cn] = 0.1
-        output = {'quantization': { 'quantization': quantization }, 'epsilons': epsilons }
+        output = {'quantization': { 'quantization': quantization }, 'epsilons': {}, 'defaultEpsilons': defaultEpsilons }
         f.write(json.dumps(output))
 
 if __name__=='__main__':

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -70,6 +70,7 @@
                         node_modules/rx/**,
                         dataViews/**,
                         ui/**,
+                        img/**,
                         WEB-INF/**,
                         META-INF/**,
                         *

--- a/web/src/main/webapp/dataViews/heatmapView.ts
+++ b/web/src/main/webapp/dataViews/heatmapView.ts
@@ -379,7 +379,7 @@ export class HeatmapView extends ChartView {
             isAscending: true,
         }]);
         const page = this.dataset.newPage(new PageTitle("Table"), this.page);
-        const table = new TableView(this.remoteObjectId, this.rowCount, this.schema, page, null);
+        const table = new TableView(this.remoteObjectId, this.rowCount, this.schema, page);
         page.setDataView(table);
         table.schema = this.schema;
         const rr = table.createNextKRequest(order, null, Resolution.tableRowsOnScreen);

--- a/web/src/main/webapp/dataViews/histogram2DView.ts
+++ b/web/src/main/webapp/dataViews/histogram2DView.ts
@@ -542,7 +542,7 @@ export class Histogram2DView extends HistogramViewBase {
         } ]);
 
         const page = this.dataset.newPage(new PageTitle("Table"), this.page);
-        const table = new TableView(this.remoteObjectId, this.rowCount, this.schema, page, null);
+        const table = new TableView(this.remoteObjectId, this.rowCount, this.schema, page);
         const rr = table.createNextKRequest(order, null, Resolution.tableRowsOnScreen);
         page.setDataView(table);
         rr.invoke(new NextKReceiver(page, table, rr, false, order, null));

--- a/web/src/main/webapp/dataViews/histogramView.ts
+++ b/web/src/main/webapp/dataViews/histogramView.ts
@@ -422,7 +422,7 @@ export class HistogramView extends HistogramViewBase /*implements IScrollTarget*
     protected showTable(): void {
         const newPage = this.dataset.newPage(
             new PageTitle("Table"), this.page);
-        const table = new TableView(this.remoteObjectId, this.rowCount, this.schema, newPage, null);
+        const table = new TableView(this.remoteObjectId, this.rowCount, this.schema, newPage);
         newPage.setDataView(table);
         table.schema = this.schema;
 

--- a/web/src/main/webapp/dataViews/schemaView.ts
+++ b/web/src/main/webapp/dataViews/schemaView.ts
@@ -419,7 +419,7 @@ export class SchemaView extends TSViewBase {
         const newPage = this.dataset.newPage(new PageTitle("Selected columns"), this.page);
         const selected = this.display.getSelectedRows();
         const newSchema = this.schema.filter((c) => selected.has(this.schema.columnIndex(c.name)));
-        const tv = new TableView(this.remoteObjectId, this.rowCount, newSchema, newPage, null);
+        const tv = new TableView(this.remoteObjectId, this.rowCount, newSchema, newPage);
         newPage.setDataView(tv);
         const nkl: NextKList = {
             rowsScanned: this.rowCount,

--- a/web/src/main/webapp/dataViews/spectrumView.ts
+++ b/web/src/main/webapp/dataViews/spectrumView.ts
@@ -114,7 +114,7 @@ export class SpectrumReceiver extends OnCompleteReceiver<EigenVal> {
             }
             const rr = this.originator.createCorrelationMatrixRequest(this.colNames, this.rowCount, true);
             const newestPage = this.newPage.dataset.newPage(new PageTitle("Table"), this.newPage);
-            const table = new TableView(this.remoteObjectId, this.rowCount, this.schema, newestPage, null);
+            const table = new TableView(this.remoteObjectId, this.rowCount, this.schema, newestPage);
             newestPage.setDataView(table);
             const order  = new RecordOrder([]);
             rr.invoke(new CorrelationMatrixReceiver(newestPage, table, rr, order, numComponents, projectionName));

--- a/web/src/main/webapp/dataViews/trellisHeatmapView.ts
+++ b/web/src/main/webapp/dataViews/trellisHeatmapView.ts
@@ -265,7 +265,7 @@ export class TrellisHeatmapView extends TrellisChartView {
 
     public showTable(): void {
         const newPage = this.dataset.newPage(new PageTitle("Table"), this.page);
-        const table = new TableView(this.remoteObjectId, this.rowCount, this.schema, newPage, null);
+        const table = new TableView(this.remoteObjectId, this.rowCount, this.schema, newPage);
         newPage.setDataView(table);
         table.schema = this.schema;
 

--- a/web/src/main/webapp/dataViews/trellisHistogram2DView.ts
+++ b/web/src/main/webapp/dataViews/trellisHistogram2DView.ts
@@ -252,7 +252,7 @@ export class TrellisHistogram2DView extends TrellisChartView {
 
     protected showTable(): void {
         const newPage = this.dataset.newPage(new PageTitle("Table"), this.page);
-        const table = new TableView(this.remoteObjectId, this.rowCount, this.schema, newPage, null);
+        const table = new TableView(this.remoteObjectId, this.rowCount, this.schema, newPage);
         newPage.setDataView(table);
         table.schema = this.schema;
 

--- a/web/src/main/webapp/dataViews/trellisHistogramView.ts
+++ b/web/src/main/webapp/dataViews/trellisHistogramView.ts
@@ -158,7 +158,7 @@ export class TrellisHistogramView extends TrellisChartView {
 
     protected showTable(): void {
         const newPage = this.dataset.newPage(new PageTitle("Table"), this.page);
-        const table = new TableView(this.remoteObjectId, this.rowCount, this.schema, newPage, null);
+        const table = new TableView(this.remoteObjectId, this.rowCount, this.schema, newPage);
         newPage.setDataView(table);
         table.schema = this.schema;
 

--- a/web/src/main/webapp/img/jsoneditor-icons.svg
+++ b/web/src/main/webapp/img/jsoneditor-icons.svg
@@ -1,0 +1,1 @@
+../node_modules/jsoneditor/dist/img/jsoneditor-icons.svg

--- a/web/src/main/webapp/index.html
+++ b/web/src/main/webapp/index.html
@@ -25,6 +25,7 @@
     <link rel="shortcut icon" href="/favicon.png" />
     <title>Hillview</title>
     <link rel="stylesheet" href="hillview.css">
+    <link rel="stylesheet" href="jsoneditor.css">
     <script type="text/javascript" src="./bundle.js" charset="utf-8"></script>
     <script>
         //noinspection ThisExpressionReferencesGlobalObjectJS

--- a/web/src/main/webapp/initialObject.ts
+++ b/web/src/main/webapp/initialObject.ts
@@ -21,7 +21,7 @@ import {
     FileSetDescription,
     FileSizeSketchInfo,
     JdbcConnectionInformation,
-    RemoteObjectId, UIConfig,
+    RemoteObjectId,
 } from "./javaBridge";
 import {OnCompleteReceiver, RemoteObject} from "./rpc";
 import {BaseReceiver} from "./tableTarget";
@@ -138,14 +138,14 @@ class FilePruneReceiver extends OnCompleteReceiver<RemoteObjectId> {
 export class RemoteTableReceiver extends BaseReceiver {
     /**
      * Create a renderer for a new table.
-     * @param page            Parent page initiating this request.
+     * @param loadMenuPage    Parent page initiating this request, always the page of the LoadMenu.
      * @param data            Data that has been loaded.
      * @param operation       Operation that will bring the results.
      * @param progressInfo    Description of the files that are being loaded.
      */
-    constructor(page: FullPage, operation: ICancellable<RemoteObjectId>, protected data: DataLoaded,
+    constructor(loadMenuPage: FullPage, operation: ICancellable<RemoteObjectId>, protected data: DataLoaded,
                 progressInfo: string) {
-        super(page, operation, progressInfo, null);
+        super(loadMenuPage, operation, progressInfo, null);
     }
 
     public run(): void {
@@ -153,7 +153,7 @@ export class RemoteTableReceiver extends BaseReceiver {
         const rr = this.remoteObject.createGetSummaryRequest();
         rr.chain(this.operation);
         const title = getDescription(this.data);
-        const dataset = new DatasetView(this.remoteObject.remoteObjectId, title, this.data);
+        const dataset = new DatasetView(this.remoteObject.remoteObjectId, title, this.data, this.page);
         const newPage = dataset.newPage(new PageTitle(title), null);
         rr.invoke(new SchemaReceiver(newPage, rr, this.remoteObject, dataset, null, null));
     }

--- a/web/src/main/webapp/javaBridge.ts
+++ b/web/src/main/webapp/javaBridge.ts
@@ -95,7 +95,17 @@ export interface ColumnQuantization {
 
 export interface PrivacySchema {
     quantization: { quantization: { [colName: string]: ColumnQuantization } };
-    epsilons: { [colName: string]: number };
+    epsilons: { [colNames: string]: number };
+    // map a column count (encoded as a string, to suit JSON label requirements) to an epsilon
+    defaultEpsilons: { [count: string]: number };
+    defaultEpsilon: number;
+}
+
+// This class is used to package a string argument that should be sent
+// unchanged through a remote all.
+export class JsonString {
+    constructor(private value: string) {}
+    public toJSON(): string { return this.value; }
 }
 
 export interface TableSummary {

--- a/web/src/main/webapp/jsoneditor.css
+++ b/web/src/main/webapp/jsoneditor.css
@@ -1,0 +1,1 @@
+node_modules/jsoneditor/dist/jsoneditor.css

--- a/web/src/main/webapp/loadMenu.ts
+++ b/web/src/main/webapp/loadMenu.ts
@@ -363,7 +363,7 @@ export class LoadMenu extends RemoteObject implements IDataView {
             return;
         }
         this.page.reportError("Reconstructing " + json.views.length + " views");
-        const dataset = new DatasetView(json.remoteObjectId, title, json);
+        const dataset = new DatasetView(json.remoteObjectId, title, json, this.page);
         const success = dataset.reconstruct(json);
         if (!success)
             this.page.reportError("Error reconstructing view");

--- a/web/src/main/webapp/package.json
+++ b/web/src/main/webapp/package.json
@@ -24,10 +24,12 @@
     "d3-shape": "^1.2.0",
     "d3-time": "^1.0.8",
     "file-saver": "^1.3.8",
+    "jsoneditor": "^7.2.1",
     "pako": "^1.0.6",
     "rx": "^4.1.0"
   },
   "devDependencies": {
+    "@types/jsoneditor": "^5.28.1",
     "@types/d3-axis": "^1.0.8",
     "@types/d3-drag": "^1.2.0",
     "@types/d3-format": "^1.2.1",

--- a/web/src/main/webapp/toplevel.ts
+++ b/web/src/main/webapp/toplevel.ts
@@ -80,7 +80,7 @@ export class HillviewToplevel implements IHtmlElement {
         return this.topLevel;
     }
 
-    public addDataset(dataset: DatasetView): void {
+    public addDataset(dataset: DatasetView, menu: ContextMenu): void {
         // tab names never change once tabs are created.  They are also unique.
         // The tab name is not the dataset name; the dataset name is displayed in the tab.
         const tabName = "tab" + this.datasetCounter++;
@@ -98,17 +98,6 @@ export class HillviewToplevel implements IHtmlElement {
         cell.title = dataset.name + "\nRight-click opens a menu";
         cell.onclick = () => { if (this.select(tabName)) { this.rename(tabName); } };
         cell.className = "dataset-name";
-
-        const menu = new ContextMenu(this.topLevel, [{
-            text: "Save this tab to file",
-            action: () => dataset.saveToFile(),
-            help: "Save the views in this tab to a local file;\n" +
-            "this file can be loaded later using \"Load saved view\".",
-        }, {
-            text: "Redisplay",
-            action: () => dataset.redisplay(),
-            help: "Display again the original dataset",
-        }]);
         cell.oncontextmenu = (e) => menu.show(e);
 
         const close = document.createElement("span");


### PR DESCRIPTION
This adds additional dependencies, so one need to run ./bin/install-dependencies.sh before using it.
The "tab" of a private dataset now has a menu with an item "edit privacy policy". This shows the privacy policy as JSON; once edited all the views displayed are refreshed. @pratiksha : please take a look.
