### PR TITLE
Facilities for saving schema and private key

### DIFF
--- a/platform/src/main/java/org/hillview/main/RNGBenchmarks.java
+++ b/platform/src/main/java/org/hillview/main/RNGBenchmarks.java
@@ -5,6 +5,7 @@ import org.hillview.dataset.api.Pair;
 import org.hillview.security.SecureLaplace;
 import org.hillview.utils.HashUtil;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Random;
 
@@ -37,7 +38,7 @@ public class RNGBenchmarks extends Benchmarks {
     }
 
     static void runAES(ArrayList<Pair<Integer, Integer>> pairs) {
-        SecureLaplace laplace = new SecureLaplace();
+        SecureLaplace laplace = new SecureLaplace(Paths.get("./hillview_test_key"));
         for (Pair<Integer, Integer> p : pairs) {
             laplace.sampleLaplace(p, scale);
         }

--- a/platform/src/main/java/org/hillview/table/PrivacySchema.java
+++ b/platform/src/main/java/org/hillview/table/PrivacySchema.java
@@ -18,6 +18,7 @@
 package org.hillview.table;
 
 import org.hillview.dataset.api.IJson;
+import org.hillview.security.SecureLaplace;
 import org.hillview.table.columns.ColumnQuantization;
 
 import javax.annotation.Nullable;
@@ -56,11 +57,14 @@ public class PrivacySchema implements IJson, Serializable {
      */
     final private double defaultEpsilon;
 
+    final private SecureLaplace laplace;
+
     public PrivacySchema(QuantizationSchema quantization) {
         this.quantization = quantization;
         this.epsilons = new LinkedHashMap<String, Double>();
         this.defaultEpsilons = new LinkedHashMap<String, Double>();
         this.defaultEpsilon = .001;
+        this.laplace = new SecureLaplace(Paths.get("./default_key")); // TODO: Curator should be able to create a new schema from scratch.
     }
 
     @Nullable

--- a/platform/src/main/java/org/hillview/table/PrivacySchema.java
+++ b/platform/src/main/java/org/hillview/table/PrivacySchema.java
@@ -21,9 +21,12 @@ import org.hillview.dataset.api.IJson;
 import org.hillview.table.columns.ColumnQuantization;
 
 import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -113,5 +116,10 @@ public class PrivacySchema implements IJson, Serializable {
             throw new RuntimeException(e);
         }
         return loadFromString(contents);
+    }
+
+    public void saveToFile(String metadataFile) throws IOException {
+        String jsonSchema = IJson.gsonInstance.toJson(this, PrivacySchema.class);
+        Files.write(Paths.get(metadataFile), jsonSchema.getBytes());
     }
 }

--- a/platform/src/main/java/org/hillview/utils/Utilities.java
+++ b/platform/src/main/java/org/hillview/utils/Utilities.java
@@ -389,7 +389,7 @@ public class Utilities {
 
         for (int i = INT_SIZE - 1; i >= 0; i--) {
             arr[i]          = (byte)(p.first  >> 8*i);
-            arr[i+ INT_SIZE] = (byte)(p.second >> 8*i);
+            arr[i+INT_SIZE] = (byte)(p.second >> 8*i);
         }
     }
 

--- a/platform/src/test/java/org/hillview/test/security/SecureLaplaceTest.java
+++ b/platform/src/test/java/org/hillview/test/security/SecureLaplaceTest.java
@@ -5,10 +5,12 @@ import org.hillview.security.SecureLaplace;
 import org.hillview.test.BaseTest;
 import org.junit.Test;
 
+import java.nio.file.Paths;
+
 public class SecureLaplaceTest extends BaseTest {
     @Test
     public void LaplaceTest() {
-        SecureLaplace sl = new SecureLaplace();
+        SecureLaplace sl = new SecureLaplace(Paths.get("./hillview_test_key"));
         double scale = 10;
         Pair<Integer, Integer> idx = new Pair<>(10, 11);
         double noise = sl.sampleLaplace(idx, scale);

--- a/platform/src/test/java/org/hillview/test/table/PrivacySchemaTest.java
+++ b/platform/src/test/java/org/hillview/test/table/PrivacySchemaTest.java
@@ -17,6 +17,7 @@
 
 package org.hillview.test.table;
 
+import org.hillview.dataset.api.IJson;
 import org.hillview.table.PrivacySchema;
 import org.hillview.table.QuantizationSchema;
 import org.hillview.table.columns.ColumnQuantization;
@@ -27,6 +28,11 @@ import org.hillview.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.management.loading.PrivateClassLoader;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 
 public class PrivacySchemaTest extends BaseTest {
@@ -91,5 +97,27 @@ public class PrivacySchemaTest extends BaseTest {
         Assert.assertEquals(1, eps, .0001);
         eps = mdSchema.epsilon("col1", "col2", "col3");
         Assert.assertEquals(.001, eps, .0001);
+    }
+
+    @Test
+    public void saveTest() throws IOException {
+        HashMap<String, ColumnQuantization> mdMap = new HashMap<String, ColumnQuantization>();
+        ColumnQuantization md1 = new DoubleColumnQuantization(12.345, 0.0, 123.45);
+        ColumnQuantization md2 = new StringColumnQuantization(new String[] {"a", "b", "c"}, "d");
+        QuantizationSchema qs = new QuantizationSchema();
+        qs.set("col1", md1);
+        qs.set("col2", md2);
+        PrivacySchema mdSchema = new PrivacySchema(qs);
+        mdSchema.setEpsilon("col1", .1);
+        mdSchema.setEpsilon("col2", .5);
+
+        String fname = "test.json";
+        mdSchema.saveToFile(fname);
+        assert(Files.exists(Paths.get(fname)));
+
+        PrivacySchema loadSchema = PrivacySchema.loadFromFile(fname);
+        assert(IJson.gsonInstance.toJson(loadSchema).equals(IJson.gsonInstance.toJson(mdSchema)));
+
+        Files.delete(Paths.get(fname));
     }
 }

--- a/web/src/main/java/org/hillview/benchmarks/DPBenchmarks.java
+++ b/web/src/main/java/org/hillview/benchmarks/DPBenchmarks.java
@@ -103,7 +103,7 @@ public class DPBenchmarks extends Benchmarks {
         String privacyMetadataFile = DPWrapper.privacyMetadataFile("data/ontime_private");
         assert privacyMetadataFile != null;
         PrivacySchema ps = PrivacySchema.loadFromFile(privacyMetadataFile);
-        this.flightsWrapper = new DPWrapper(ps);
+        this.flightsWrapper = new DPWrapper(ps, privacyMetadataFile);
         this.ontimeSchema = Schema.readFromJsonFile(Paths.get("data/ontime/short.schema"));
 
         IDataSet<ITable> data = this.flights;

--- a/web/src/main/java/org/hillview/benchmarks/DPBenchmarks.java
+++ b/web/src/main/java/org/hillview/benchmarks/DPBenchmarks.java
@@ -166,7 +166,7 @@ public class DPBenchmarks extends Benchmarks {
             DyadicDecomposition d1 = new NumericDyadicDecomposition(
                 (DoubleColumnQuantization)q0, buckDes0);
             if (conf.usePostProcessing)
-                postprocess = x -> new PrivateHeatmap(d0, d1, x, epsilon);
+                postprocess = x -> new PrivateHeatmap(d0, d1, x, epsilon, this.flightsWrapper.laplace);
         }
 
         assert this.ontimeSchema != null;
@@ -212,7 +212,7 @@ public class DPBenchmarks extends Benchmarks {
             DyadicDecomposition d = new NumericDyadicDecomposition(
                 (DoubleColumnQuantization)q, buckDes);
             if (conf.usePostProcessing)
-                postprocess = x -> new PrivateHistogram(d, x, epsilon, false);
+                postprocess = x -> new PrivateHistogram(d, x, epsilon, false, this.flightsWrapper.laplace);
         }
 
         assert this.ontimeSchema != null;

--- a/web/src/main/java/org/hillview/dataStructures/PrivateHeatmap.java
+++ b/web/src/main/java/org/hillview/dataStructures/PrivateHeatmap.java
@@ -17,10 +17,10 @@ public class PrivateHeatmap implements Serializable, IJson {
     private SecureLaplace laplace;
 
     public PrivateHeatmap(DyadicDecomposition d0, DyadicDecomposition d1,
-                          Heatmap heatmap, double epsilon) {
+                          Heatmap heatmap, double epsilon, SecureLaplace laplace) {
         this.heatmap = heatmap;
         this.epsilon = epsilon;
-        this.laplace = new SecureLaplace();
+        this.laplace = laplace;
         this.addDyadicLaplaceNoise(d0, d1);
     }
 

--- a/web/src/main/java/org/hillview/dataStructures/PrivateHistogram.java
+++ b/web/src/main/java/org/hillview/dataStructures/PrivateHistogram.java
@@ -39,7 +39,7 @@ public class PrivateHistogram extends HistogramPrefixSum implements IJson {
      */
     public long noiseForRange(int left, int right,
                               double scale, double baseVariance,
-            /*out*/Noise noise) {
+                             /*out*/Noise noise) {
         List<Pair<Integer, Integer>> intervals = DyadicDecomposition.kadicDecomposition(left, right, 2);
         noise.clear();
         for (Pair<Integer, Integer> x : intervals) {
@@ -57,6 +57,7 @@ public class PrivateHistogram extends HistogramPrefixSum implements IJson {
      * @param baseVariance:  factor added to variance for each bucket
      * @param isCdf: If true, computes the noise based on the dyadic decomposition of the interval [0, bucket right leaf]
      *             rather than [bucket left leaf, bucket right leaf].
+     * @param decomposition: Specifies the dyadic decomposition to use when computing the nodes for this bucket.
      * Returns the noise and the total variance of the variables used to compute the noise.
      */
     @SuppressWarnings("ConstantConditions")

--- a/web/src/main/java/org/hillview/dataStructures/PrivateHistogram.java
+++ b/web/src/main/java/org/hillview/dataStructures/PrivateHistogram.java
@@ -1,8 +1,12 @@
 package org.hillview.dataStructures;
 
 import org.hillview.dataset.api.IJson;
+import org.hillview.dataset.api.Pair;
+import org.hillview.security.SecureLaplace;
 import org.hillview.sketches.results.Histogram;
 import org.hillview.utils.HillviewLogger;
+
+import java.util.List;
 
 /**
  * Contains methods for adding privacy to a non-private histogram computed over dyadic buckets,
@@ -12,11 +16,14 @@ import org.hillview.utils.HillviewLogger;
 public class PrivateHistogram extends HistogramPrefixSum implements IJson {
     private int[] confidence;
     private final double epsilon;
+    private final SecureLaplace laplace;
 
     public PrivateHistogram(DyadicDecomposition decomposition,
                             final Histogram histogram,
-                            double epsilon, boolean isCdf) {
+                            double epsilon, boolean isCdf,
+                            SecureLaplace laplace) {
         super(histogram);
+        this.laplace = laplace;
         this.epsilon = epsilon;
         this.confidence  = new int[histogram.getBucketCount()];
         long numRngCalls = this.addDyadicLaplaceNoise(decomposition);
@@ -24,6 +31,41 @@ public class PrivateHistogram extends HistogramPrefixSum implements IJson {
         if (isCdf) {
             this.recomputeCDF(decomposition);
         }
+    }
+
+    /**
+     * Compute noise for the given [left leaf, right leaf) range using the dyadic decomposition.
+     * See also noiseForBucket.
+     */
+    public long noiseForRange(int left, int right,
+                              double scale, double baseVariance,
+            /*out*/Noise noise) {
+        List<Pair<Integer, Integer>> intervals = DyadicDecomposition.kadicDecomposition(left, right, 2);
+        noise.clear();
+        for (Pair<Integer, Integer> x : intervals) {
+            noise.noise += this.laplace.sampleLaplace(x, scale);
+            noise.variance += baseVariance;
+        }
+
+        return intervals.size();
+    }
+
+    /**
+     * Compute noise to add to this bucket using the dyadic decomposition as the PRG seed.
+     * @param bucketIdx: index of the bucket to compute noise for.
+     * @param scale:      scale of laplace distribution used to sample data
+     * @param baseVariance:  factor added to variance for each bucket
+     * @param isCdf: If true, computes the noise based on the dyadic decomposition of the interval [0, bucket right leaf]
+     *             rather than [bucket left leaf, bucket right leaf].
+     * Returns the noise and the total variance of the variables used to compute the noise.
+     */
+    @SuppressWarnings("ConstantConditions")
+    long noiseForBucket(int bucketIdx,
+                        double scale, double baseVariance,
+                        boolean isCdf, Noise noise,
+                        DyadicDecomposition decomposition) {
+        Pair<Integer, Integer> range = decomposition.bucketRange(bucketIdx, isCdf);
+        return this.noiseForRange(range.first, range.second, scale, baseVariance, noise);
     }
 
     /**
@@ -41,8 +83,8 @@ public class PrivateHistogram extends HistogramPrefixSum implements IJson {
         Noise noise = new Noise();
         for (int i = 0; i < this.cdfBuckets.length; i++) {
             noise.clear();
-            decomposition.noiseForBucket(
-                    i, scale, baseVariance, true, noise);
+            this.noiseForBucket(
+                    i, scale, baseVariance, true, noise, decomposition);
             this.cdfBuckets[i] += noise.noise;
             if (i > 0) {
                 // Postprocess CDF to be monotonically increasing
@@ -68,8 +110,8 @@ public class PrivateHistogram extends HistogramPrefixSum implements IJson {
         Noise noise = new Noise();
         long totalIntervals = 0;
         for (int i = 0; i < this.histogram.buckets.length; i++) {
-            long nIntervals = decomposition.noiseForBucket(
-                    i, scale, baseVariance, false, noise);
+            long nIntervals = this.noiseForBucket(
+                    i, scale, baseVariance, false, noise, decomposition);
             totalIntervals += nIntervals;
             this.histogram.buckets[i] += noise.noise;
             this.confidence[i] = (int)noise.getConfidence();

--- a/web/src/main/java/org/hillview/targets/DPWrapper.java
+++ b/web/src/main/java/org/hillview/targets/DPWrapper.java
@@ -42,6 +42,7 @@ import org.hillview.utils.Utilities;
 
 import javax.annotation.Nullable;
 import java.io.File;
+import java.io.IOException;
 import java.util.function.BiFunction;
 
 /**
@@ -57,6 +58,7 @@ public class DPWrapper {
             this.privacySchema = ps;
         }
 
+        /* Set the privacy schema locally but do not persist it. */
         void setPrivacySchema(PrivacySchema ps) {
             this.privacySchema = ps;
         }
@@ -66,15 +68,18 @@ public class DPWrapper {
     final ColumnLimits columnLimits;
     /* Global parameters for differentially-private histograms using the binary mechanism. */
     protected final PrivacySchemaContainer container;
+    final String schemaFilename;
 
-    public DPWrapper(PrivacySchema privacySchema) {
+    public DPWrapper(PrivacySchema privacySchema, String schemaFilename) {
         this.columnLimits = new ColumnLimits();
         this.container = new PrivacySchemaContainer(privacySchema);
+        this.schemaFilename = schemaFilename;
     }
 
     DPWrapper(DPWrapper other) {
         this.container = other.container;
         this.columnLimits = new ColumnLimits(other.columnLimits);
+        this.schemaFilename = other.schemaFilename;
     }
 
     /**
@@ -102,6 +107,16 @@ public class DPWrapper {
 
     void setPrivacySchema(PrivacySchema ps) {
         this.container.setPrivacySchema(ps);
+    }
+
+    /* Persist the privacy schema to disk, overwriting the existing schema. */
+    void savePrivacySchema() {
+        try {
+            this.container.privacySchema.saveToFile(this.schemaFilename);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Could not save privacy schema to file");
+        }
     }
 
     public static class PrivacySummary implements IJson {

--- a/web/src/main/java/org/hillview/targets/InitialObjectTarget.java
+++ b/web/src/main/java/org/hillview/targets/InitialObjectTarget.java
@@ -110,7 +110,7 @@ public class InitialObjectTarget extends RpcTarget {
             this.runMap(this.emptyDataset, map,
                     (e, c) -> {
                         try {
-                            return new PrivateSimpleDBTarget(conn, c, privacySchema);
+                            return new PrivateSimpleDBTarget(conn, c, privacySchema, privacyMetadataFile);
                         } catch (SQLException ex) {
                             throw new RuntimeException(ex);
                         }

--- a/web/src/main/java/org/hillview/targets/PrivateFileDescriptionTarget.java
+++ b/web/src/main/java/org/hillview/targets/PrivateFileDescriptionTarget.java
@@ -14,10 +14,12 @@ import org.hillview.table.api.ITable;
 
 public class PrivateFileDescriptionTarget extends FileDescriptionTarget {
     private PrivacySchema metadata;
+    private String schemaFilename;
 
     PrivateFileDescriptionTarget(IDataSet<IFileReference> files, HillviewComputation computation, String file) {
         super(files, computation);
         this.metadata = PrivacySchema.loadFromFile(file);
+        this.schemaFilename = file;
     }
 
     @HillviewRpc
@@ -29,6 +31,6 @@ public class PrivateFileDescriptionTarget extends FileDescriptionTarget {
     @HillviewRpc
     public void loadTable(RpcRequest request, RpcRequestContext context) {
         IMap<IFileReference, ITable> loader = new LoadFilesMap();
-        this.runMap(this.files, loader, (d, c) -> new PrivateTableTarget(d, c, metadata), request, context);
+        this.runMap(this.files, loader, (d, c) -> new PrivateTableTarget(d, c, metadata, schemaFilename), request, context);
     }
 }

--- a/web/src/main/java/org/hillview/targets/PrivateSimpleDBTarget.java
+++ b/web/src/main/java/org/hillview/targets/PrivateSimpleDBTarget.java
@@ -53,9 +53,9 @@ public class PrivateSimpleDBTarget extends SimpleDBTarget implements IPrivateDat
     private final DPWrapper wrapper;
 
     PrivateSimpleDBTarget(JdbcConnectionInformation conn, HillviewComputation c,
-                          PrivacySchema privacySchema) throws SQLException {
+                          PrivacySchema privacySchema, String schemaFilename) throws SQLException {
         super(conn, c);
-        this.wrapper = new DPWrapper(privacySchema);
+        this.wrapper = new DPWrapper(privacySchema, schemaFilename);
         this.database.connect();
     }
 

--- a/web/src/main/java/org/hillview/targets/PrivateSimpleDBTarget.java
+++ b/web/src/main/java/org/hillview/targets/PrivateSimpleDBTarget.java
@@ -122,8 +122,8 @@ public class PrivateSimpleDBTarget extends SimpleDBTarget implements IPrivateDat
         ISketch<ITable, Pair<Histogram, Histogram>> sk = new PrecomputedSketch<ITable, Pair<Histogram, Histogram>>(result);
         this.runCompleteSketch(this.table, sk, (e, c) ->
                 new Pair<PrivateHistogram, PrivateHistogram>(
-                        new PrivateHistogram(d0, Converters.checkNull(e.first), epsilon, false),
-                        new PrivateHistogram(d1, Converters.checkNull(e.second), epsilon, true)),
+                        new PrivateHistogram(d0, Converters.checkNull(e.first), epsilon, false, this.wrapper.laplace),
+                        new PrivateHistogram(d1, Converters.checkNull(e.second), epsilon, true, this.wrapper.laplace)),
                 request, context);
     }
 
@@ -178,7 +178,7 @@ public class PrivateSimpleDBTarget extends SimpleDBTarget implements IPrivateDat
         Converters.checkNull(q1);
         DyadicDecomposition d0 = info[0].getDecomposition(q0);
         DyadicDecomposition d1 = info[1].getDecomposition(q1);
-        PrivateHeatmap result = new PrivateHeatmap(d0, d1, heatmap, epsilon);
+        PrivateHeatmap result = new PrivateHeatmap(d0, d1, heatmap, epsilon, this.wrapper.laplace);
         ISketch<ITable, Heatmap> sk = new PrecomputedSketch<ITable, Heatmap>(result.heatmap);
         this.runCompleteSketch(this.table, sk, (e, c) -> e, request, context);
     }

--- a/web/src/main/java/org/hillview/targets/PrivateTableTarget.java
+++ b/web/src/main/java/org/hillview/targets/PrivateTableTarget.java
@@ -26,9 +26,9 @@ public class PrivateTableTarget extends RpcTarget implements IPrivateDataset {
     public final DPWrapper wrapper;
 
     PrivateTableTarget(IDataSet<ITable> table, HillviewComputation computation,
-                       PrivacySchema privacySchema) {
+                       PrivacySchema privacySchema, String schemaFilename) {
         super(computation);
-        this.wrapper = new DPWrapper(privacySchema);
+        this.wrapper = new DPWrapper(privacySchema, schemaFilename);
         this.table = table;
         this.registerObject();
     }
@@ -50,6 +50,15 @@ public class PrivateTableTarget extends RpcTarget implements IPrivateDataset {
     public void changePrivacy(RpcRequest request, RpcRequestContext context) {
         this.wrapper.setPrivacySchema(request.parseArgs(PrivacySchema.class));
         HillviewLogger.instance.info("Updated privacy schema");
+        PrecomputedSketch<ITable, JsonString> empty =
+                new PrecomputedSketch<ITable, JsonString>(new JsonString("{}"));
+        this.runCompleteSketch(this.table, empty, (d, c) -> d, request, context);
+    }
+
+    @HillviewRpc
+    public void savePrivacy(RpcRequest request, RpcRequestContext context) {
+        this.wrapper.savePrivacySchema();
+        HillviewLogger.instance.info("Saved privacy schema");
         PrecomputedSketch<ITable, JsonString> empty =
                 new PrecomputedSketch<ITable, JsonString>(new JsonString("{}"));
         this.runCompleteSketch(this.table, empty, (d, c) -> d, request, context);

--- a/web/src/main/java/org/hillview/targets/PrivateTableTarget.java
+++ b/web/src/main/java/org/hillview/targets/PrivateTableTarget.java
@@ -90,8 +90,8 @@ public class PrivateTableTarget extends RpcTarget implements IPrivateDataset {
                 new ConcurrentSketch<ITable, Histogram, Histogram>(sk, cdf);
         this.runCompleteSketch(this.table, csk, (e, c) ->
                 new Pair<PrivateHistogram, PrivateHistogram>(
-                        new PrivateHistogram(d0, Converters.checkNull(e.first), epsilon, false),
-                        new PrivateHistogram(d1, Converters.checkNull(e.second), epsilon, true)),
+                        new PrivateHistogram(d0, Converters.checkNull(e.first), epsilon, false, this.wrapper.laplace),
+                        new PrivateHistogram(d1, Converters.checkNull(e.second), epsilon, true, this.wrapper.laplace)),
                 request, context);
     }
 
@@ -173,7 +173,7 @@ public class PrivateTableTarget extends RpcTarget implements IPrivateDataset {
         HeatmapSketch sk = new HeatmapSketch(
                 b0, b1, info[0].cd.name, info[1].cd.name, 1.0, 0, q0, q1);
         this.runCompleteSketch(this.table, sk, (e, c) ->
-                new PrivateHeatmap(d0, d1, e, epsilon).heatmap, request, context);
+                new PrivateHeatmap(d0, d1, e, epsilon, this.wrapper.laplace).heatmap, request, context);
     }
 
     @HillviewRpc

--- a/web/src/test/java/org/hillview/HistogramAccuracyTest.java
+++ b/web/src/test/java/org/hillview/HistogramAccuracyTest.java
@@ -27,6 +27,7 @@ import org.hillview.dataset.api.IDataSet;
 import org.hillview.dataset.api.IMap;
 import org.hillview.maps.FindFilesMap;
 import org.hillview.maps.LoadFilesMap;
+import org.hillview.security.SecureLaplace;
 import org.hillview.sketches.HistogramSketch;
 import org.hillview.sketches.results.Histogram;
 import org.hillview.storage.FileSetDescription;
@@ -42,6 +43,7 @@ import org.hillview.table.columns.DoubleColumnQuantization;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.file.Paths;
 import java.util.List;
 
 @SuppressWarnings("FieldCanBeLocal")
@@ -85,7 +87,8 @@ public class HistogramAccuracyTest {
 
             Histogram hist = table.blockingSketch(sk); // Leaf counts.
             Assert.assertNotNull(hist);
-            PrivateHistogram ph = new PrivateHistogram(dd, hist, epsilon, false);
+            SecureLaplace laplace = new SecureLaplace(Paths.get("./hillview_test_key"));
+            PrivateHistogram ph = new PrivateHistogram(dd, hist, epsilon, false, laplace);
 
             int totalLeaves = dd.getQuantizationIntervalCount();
             double scale = Math.log(totalLeaves) / Math.log(2);
@@ -98,7 +101,7 @@ public class HistogramAccuracyTest {
             Noise noise = new Noise();
             for (int left = 0; left < hist.getBucketCount(); left++) {
                 for (int right = left; right < hist.getBucketCount(); right++) {
-                    dd.noiseForRange(left, right,
+                    ph.noiseForRange(left, right,
                             scale, baseVariance, noise);
                     sqtot += Math.pow(noise.noise, 2);
                     abstot += Math.abs(noise.noise);


### PR DESCRIPTION
Adds a "save" button to persist an edited privacy schema, and refactors the secure sampling implementation to generate a new key or read one from file.