### PR TITLE
fixed tomcat start on Windows

### DIFF
--- a/bin/hillview-start.bat
+++ b/bin/hillview-start.bat
@@ -1,6 +1,7 @@
 REM a script which starts Hillview on a Windows machine
 
+set CATALINA_HOME=..\apache-tomcat-9.0.4
 call detect-java.bat
 start /B java -jar ..\platform\target\hillview-server-jar-with-dependencies.jar 127.0.0.1:3569
-start /B ..\apache-tomcat-9.0.4\bin\catalina.sh run
+start /B ..\apache-tomcat-9.0.4\bin\catalina.bat run
 start /B http://localhost:8080


### PR DESCRIPTION
On Windows (at least without WLS), its catalina.bat instead of .sh. Also set CATALINA_HOME since tomcat guessing it didn't work for some reason.