### PR TITLE
Migrate from Nashorn to GraalJS

### DIFF
--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -300,7 +300,13 @@
             <groupId>io.krakens</groupId>
             <artifactId>java-grok</artifactId>
             <version>0.1.9</version>
-            </dependency>
+        </dependency>
+        <!-- GraalJS for Javascript-on-JVM support -->
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js</artifactId>
+            <version>20.1.0</version>
+        </dependency>
     </dependencies>
     <build>
         <extensions>

--- a/platform/src/main/java/org/hillview/table/rows/JSVirtualRowSnapshot.java
+++ b/platform/src/main/java/org/hillview/table/rows/JSVirtualRowSnapshot.java
@@ -17,15 +17,13 @@
 
 package org.hillview.table.rows;
 
-import jdk.nashorn.api.scripting.JSObject;
+import org.graalvm.polyglot.Context;
 import org.hillview.table.Schema;
 import org.hillview.table.api.ContentsKind;
 import org.hillview.table.api.IColumn;
 import org.hillview.table.api.ITable;
 
 import javax.annotation.Nullable;
-import javax.script.ScriptEngine;
-import javax.script.ScriptException;
 import java.util.HashMap;
 
 /**
@@ -35,13 +33,13 @@ import java.util.HashMap;
 public class JSVirtualRowSnapshot extends VirtualRowSnapshot {
     static final long serialVersionUID = 1;
 
-    private final ScriptEngine engine;
+    private final Context engine;
 
     public JSVirtualRowSnapshot(
             ITable table, Schema schema,
             @Nullable
             HashMap<String, String> columnRenameMap,
-            ScriptEngine engine) {
+            Context engine) {
         super(table, schema, columnRenameMap);
         this.engine = engine;
     }
@@ -53,12 +51,7 @@ public class JSVirtualRowSnapshot extends VirtualRowSnapshot {
         if (col.getDescription().kind == ContentsKind.Date) {
             double dateEncoding = super.getDouble((String)key);
             // https://stackoverflow.com/questions/33110942/supply-javascript-date-to-nashorn-script
-            try {
-                //noinspection RedundantCast
-                return (JSObject) this.engine.eval("new Date(" + dateEncoding + ")");
-            } catch (ScriptException e) {
-                throw new RuntimeException(e);
-            }
+            return this.engine.eval("js","new Date(" + dateEncoding + ")");
         }
 
         return super.get(key);


### PR DESCRIPTION
Nashorn has been deprecated as of JDK 11, and will not be available at all from JDK 15 onwards: https://openjdk.java.net/jeps/372. This patch migrates our Nashorn-based code to use GraalJS
instead.

It should run on stock JDKs, including JDK 8 (I tested it with JDK 12). The JS will be interpreted on top of the JVM, as I believe was also the case with Nashorn. It should benefit from GraalVM's JIT if users run Hillview using the GraalJDK instead.

I haven't E2E tested this yet from a browser, so please try it out before you merge. It passes all the tests that used to be in `JavascriptNashornTest` (now renamed to `JavascriptTest`).