### PR TITLE
added 'as any' to declare the variable as any

### DIFF
--- a/web/src/main/webapp/ui/fullPage.ts
+++ b/web/src/main/webapp/ui/fullPage.ts
@@ -342,7 +342,7 @@ export class FullPage implements IHtmlElement {
      * @param {ViewKind} viewKind  Kind of view that help is sought for.
      */
     public static helpUrl(viewKind: ViewKind): string {
-        let ref = helpUrl.get(viewKind);
+        let ref = (helpUrl as any).get(viewKind);
         // strip parentheses from front and back
         ref = ref.replace(/^\(/, "").replace(/\)$/, "");
         return "https://github.com/vmware/hillview/blob/master/docs/userManual.md" + ref;


### PR DESCRIPTION
Because of the `noImplicitAny` declaration at ` web/src/main/webapp/tsconfig.json`, here are the files that failed during compilation:
1.  web/src/main/webapp/ui/fullPage.ts(345,27)
Fixed by adding  `as any`
2. web/src/main/webapp/rpc.ts(20,21)
```
ERROR in /Users/daniar/Documents/GitPR/hillview/web/src/main/webapp/rpc.ts
./rpc.ts
[tsl] ERROR in /Users/daniar/Documents/GitPR/hillview/web/src/main/webapp/rpc.ts(20,21)
      TS7016: Could not find a declaration file for module 'rx'. '/Users/daniar/Documents/GitPR/hillview/web/src/main/webapp/node_modules/rx/index.js' implicitly has an 'any' type.
```
This happen because we are importing `rx` module that doesn't have type definition. 
Manual solution, run this locally:
```
npm add -D  @types/rx
npm link typescript
```