### PR TITLE
Expandable chart menu

### DIFF
--- a/web/src/main/webapp/dataViews/tableView.ts
+++ b/web/src/main/webapp/dataViews/tableView.ts
@@ -640,46 +640,6 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
               },
               true
             );
-            this.contextMenu.addExpandableItem(
-              {
-                text: "More...",
-                action: () => this.contextMenu.expandMenu("More..."),
-                help: "List of available charts to draw. " + "",
-              },
-              true
-            );
-            this.contextMenu.addItem({
-                text: "Histogram",
-                action: () => this.chart(this.schema.getDescriptions(this.getSelectedColNames()),
-                    this.getSelectedColCount() === 1 ? "Histogram" : "2DHistogram"),
-                help: "Plot the data in the selected columns as a histogram. " +
-                    "Applies to one or two columns only.",
-            }, selectedCount >= 1 && selectedCount <= 2);
-            this.contextMenu.addItem({
-                text: "Quartile vector",
-                action: () => this.chart(this.schema.getDescriptions(this.getSelectedColNames()), "QuartileVector"),
-                help: "Plot the data in the selected columns as a vector of quartiles. " +
-                    "Applies to one or two columns only.",
-            }, selectedCount == 2);
-            this.contextMenu.addItem({
-                text: "Heatmap",
-                action: () => this.chart(this.schema.getDescriptions(this.getSelectedColNames()), "Heatmap"),
-                help: "Plot the data in the selected columns as a heatmap. " +
-                    "Applies to two columns only.",
-            }, selectedCount === 2);
-            this.contextMenu.addItem({
-                text: "Trellis histograms",
-                action: () => this.chart(this.schema.getDescriptions(this.getSelectedColNames()),
-                    selectedCount > 2 ? "Trellis2DHistogram" : "TrellisHistogram"),
-                help: "Plot the data in the selected columns as a Trellis plot of histograms. " +
-                    "Applies to two or three columns only.",
-            }, selectedCount >= 2 && selectedCount <= 3);
-            this.contextMenu.addItem({
-                text: "Trellis heatmaps",
-                action: () => this.chart(this.schema.getDescriptions(this.getSelectedColNames()), "TrellisHeatmap"),
-                help: "Plot the data in the selected columns as a Trellis plot of heatmaps. " +
-                    "Applies to three columns only.",
-            }, selectedCount === 3 && !this.isPrivate());
             this.contextMenu.addItem({
                 text: "Rename...",
                 action: () => this.renameColumn(),
@@ -760,17 +720,80 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                         },
                         help: "Extract a value associated with a specific key."
                     }, !this.isPrivate());
-            this.contextMenu.addExpandableItem(
+            this.contextMenu.insertSubMenu( "Charts...",
               {
-                text: "Edit...",
-                action: () => this.contextMenu.expandMenu("Edit..."),
-                help: "List of available charts to draw. " + "",
+                text: "Histogram",
+                action: () =>
+                  this.chart(
+                    this.schema.getDescriptions(this.getSelectedColNames()),
+                    this.getSelectedColCount() === 1
+                      ? "Histogram"
+                      : "2DHistogram"
+                  ),
+                help:
+                  "Plot the data in the selected columns as a histogram. " +
+                  "Applies to one or two columns only.",
               },
-              true
+              selectedCount >= 1 && selectedCount <= 2
             );
-            this.contextMenu.addDummySubMenu("Charts...");
-            this.contextMenu.addDummySubMenu("More...");
-            this.contextMenu.addDummySubMenu("Edit...");
+            this.contextMenu.insertSubMenu( "Charts...",
+              {
+                text: "Quartile vector",
+                action: () =>
+                  this.chart(
+                    this.schema.getDescriptions(this.getSelectedColNames()),
+                    "QuartileVector"
+                  ),
+                help:
+                  "Plot the data in the selected columns as a vector of quartiles. " +
+                  "Applies to one or two columns only.",
+              },
+              selectedCount == 2
+            );
+            this.contextMenu.insertSubMenu( "Charts...",
+              {
+                text: "Heatmap",
+                action: () =>
+                  this.chart(
+                    this.schema.getDescriptions(this.getSelectedColNames()),
+                    "Heatmap"
+                  ),
+                help:
+                  "Plot the data in the selected columns as a heatmap. " +
+                  "Applies to two columns only.",
+              },
+              selectedCount === 2
+            );
+            this.contextMenu.insertSubMenu( "Charts...",
+              {
+                text: "Trellis histograms",
+                action: () =>
+                  this.chart(
+                    this.schema.getDescriptions(this.getSelectedColNames()),
+                    selectedCount > 2
+                      ? "Trellis2DHistogram"
+                      : "TrellisHistogram"
+                  ),
+                help:
+                  "Plot the data in the selected columns as a Trellis plot of histograms. " +
+                  "Applies to two or three columns only.",
+              },
+              selectedCount >= 2 && selectedCount <= 3
+            );
+            this.contextMenu.insertSubMenu( "Charts...",
+              {
+                text: "Trellis heatmaps",
+                action: () =>
+                  this.chart(
+                    this.schema.getDescriptions(this.getSelectedColNames()),
+                    "TrellisHeatmap"
+                  ),
+                help:
+                  "Plot the data in the selected columns as a Trellis plot of heatmaps. " +
+                  "Applies to three columns only.",
+              },
+              selectedCount === 3 && !this.isPrivate()
+            );
             this.contextMenu.show(e);
         };
     }

--- a/web/src/main/webapp/dataViews/tableView.ts
+++ b/web/src/main/webapp/dataViews/tableView.ts
@@ -639,6 +639,16 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                 help: "Plot the data in the selected columns as a histogram. " +
                     "Applies to one or two columns only.",
             }, selectedCount >= 1 && selectedCount <= 2);
+            this.contextMenu.addExpandableItem(
+              {
+                text: "Charts...",
+                action: () => this.contextMenu.expandMenu(),
+                help:
+                  "List of available charts to draw. " +
+                  "",
+              },
+              true
+            );
             this.contextMenu.addItem({
                 text: "Quartile vector",
                 action: () => this.chart(this.schema.getDescriptions(this.getSelectedColNames()), "QuartileVector"),

--- a/web/src/main/webapp/dataViews/tableView.ts
+++ b/web/src/main/webapp/dataViews/tableView.ts
@@ -632,13 +632,11 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                 action: () => this.showColumns(-1, true),
                 help: "Sort the data first on this column, in decreasing order",
             }, !this.isPrivate());
-            const chartMenuIdx = this.contextMenu.addExpandableItem(
-              {
-                text: "Charts",
-                action: () => null,
-                help: "List of available charts to draw. ",
-              }
-            );
+            const chartMenuIdx = this.contextMenu.addExpandableItem({
+              text: "Charts",
+              action: () => null,
+              help: "List of available charts to draw. ",
+            });
             this.contextMenu.addItem({
                 text: "Rename...",
                 action: () => this.renameColumn(),
@@ -732,7 +730,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                   "Plot the data in the selected columns as a histogram. " +
                   "Applies to one or two columns only.",
               },
-              selectedCount >= 1 && selectedCount <= 2, false
+              selectedCount >= 1 && selectedCount <= 2
             );
             this.contextMenu.insertSubMenu( chartMenuIdx, {
                 text: "Quartile vector",
@@ -745,7 +743,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                   "Plot the data in the selected columns as a vector of quartiles. " +
                   "Applies to one or two columns only.",
               },
-              selectedCount == 2, false
+              selectedCount == 2
             );
             this.contextMenu.insertSubMenu( chartMenuIdx, {
                 text: "Heatmap",
@@ -758,7 +756,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                   "Plot the data in the selected columns as a heatmap. " +
                   "Applies to two columns only.",
               },
-              selectedCount === 2, false
+              selectedCount === 2
             );
             this.contextMenu.insertSubMenu( chartMenuIdx, {
                 text: "Trellis histograms",
@@ -773,7 +771,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                   "Plot the data in the selected columns as a Trellis plot of histograms. " +
                   "Applies to two or three columns only.",
               },
-              selectedCount >= 2 && selectedCount <= 3, false
+              selectedCount >= 2 && selectedCount <= 3
             );
             this.contextMenu.insertSubMenu( chartMenuIdx, {
                 text: "Trellis heatmaps",
@@ -786,7 +784,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                   "Plot the data in the selected columns as a Trellis plot of heatmaps. " +
                   "Applies to three columns only.",
               },
-              selectedCount === 3 && !this.isPrivate(), true
+              selectedCount === 3 && !this.isPrivate()
             );
             this.contextMenu.show(e);
         };

--- a/web/src/main/webapp/dataViews/tableView.ts
+++ b/web/src/main/webapp/dataViews/tableView.ts
@@ -640,6 +640,14 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
               },
               true
             );
+            this.contextMenu.addExpandableItem(
+              {
+                text: "More...",
+                action: () => this.contextMenu.expandMenu("More..."),
+                help: "List of available charts to draw. " + "",
+              },
+              true
+            );
             this.contextMenu.addItem({
                 text: "Histogram",
                 action: () => this.chart(this.schema.getDescriptions(this.getSelectedColNames()),
@@ -752,7 +760,17 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                         },
                         help: "Extract a value associated with a specific key."
                     }, !this.isPrivate());
+            this.contextMenu.addExpandableItem(
+              {
+                text: "Edit...",
+                action: () => this.contextMenu.expandMenu("Edit..."),
+                help: "List of available charts to draw. " + "",
+              },
+              true
+            );
             this.contextMenu.addDummySubMenu("Charts...");
+            this.contextMenu.addDummySubMenu("More...");
+            this.contextMenu.addDummySubMenu("Edit...");
             this.contextMenu.show(e);
         };
     }

--- a/web/src/main/webapp/dataViews/tableView.ts
+++ b/web/src/main/webapp/dataViews/tableView.ts
@@ -636,7 +636,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
               {
                 text: "Charts",
                 action: () => null,
-                help: "List of available charts to draw. " + "",
+                help: "List of available charts to draw. ",
               }
             );
             this.contextMenu.addItem({

--- a/web/src/main/webapp/dataViews/tableView.ts
+++ b/web/src/main/webapp/dataViews/tableView.ts
@@ -637,8 +637,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                 text: "Charts",
                 action: () => null,
                 help: "List of available charts to draw. " + "",
-              },
-              true
+              }
             );
             this.contextMenu.addItem({
                 text: "Rename...",
@@ -733,7 +732,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                   "Plot the data in the selected columns as a histogram. " +
                   "Applies to one or two columns only.",
               },
-              selectedCount >= 1 && selectedCount <= 2
+              selectedCount >= 1 && selectedCount <= 2, false
             );
             this.contextMenu.insertSubMenu( chartMenuIdx, {
                 text: "Quartile vector",
@@ -746,7 +745,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                   "Plot the data in the selected columns as a vector of quartiles. " +
                   "Applies to one or two columns only.",
               },
-              selectedCount == 2
+              selectedCount == 2, false
             );
             this.contextMenu.insertSubMenu( chartMenuIdx, {
                 text: "Heatmap",
@@ -759,7 +758,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                   "Plot the data in the selected columns as a heatmap. " +
                   "Applies to two columns only.",
               },
-              selectedCount === 2
+              selectedCount === 2, false
             );
             this.contextMenu.insertSubMenu( chartMenuIdx, {
                 text: "Trellis histograms",
@@ -774,7 +773,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                   "Plot the data in the selected columns as a Trellis plot of histograms. " +
                   "Applies to two or three columns only.",
               },
-              selectedCount >= 2 && selectedCount <= 3
+              selectedCount >= 2 && selectedCount <= 3, false
             );
             this.contextMenu.insertSubMenu( chartMenuIdx, {
                 text: "Trellis heatmaps",
@@ -787,7 +786,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                   "Plot the data in the selected columns as a Trellis plot of heatmaps. " +
                   "Applies to three columns only.",
               },
-              selectedCount === 3 && !this.isPrivate()
+              selectedCount === 3 && !this.isPrivate(), true
             );
             this.contextMenu.show(e);
         };

--- a/web/src/main/webapp/dataViews/tableView.ts
+++ b/web/src/main/webapp/dataViews/tableView.ts
@@ -632,7 +632,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                 action: () => this.showColumns(-1, true),
                 help: "Sort the data first on this column, in decreasing order",
             }, !this.isPrivate());
-            this.contextMenu.addExpandableItem(
+            const chartMenuIdx = this.contextMenu.addExpandableItem(
               {
                 text: "Charts",
                 action: () => null,
@@ -720,8 +720,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                         },
                         help: "Extract a value associated with a specific key."
                     }, !this.isPrivate());
-            this.contextMenu.insertSubMenu( "Charts",
-              {
+            this.contextMenu.insertSubMenu( chartMenuIdx, {
                 text: "Histogram",
                 action: () =>
                   this.chart(
@@ -736,8 +735,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
               },
               selectedCount >= 1 && selectedCount <= 2
             );
-            this.contextMenu.insertSubMenu( "Charts",
-              {
+            this.contextMenu.insertSubMenu( chartMenuIdx, {
                 text: "Quartile vector",
                 action: () =>
                   this.chart(
@@ -750,8 +748,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
               },
               selectedCount == 2
             );
-            this.contextMenu.insertSubMenu( "Charts",
-              {
+            this.contextMenu.insertSubMenu( chartMenuIdx, {
                 text: "Heatmap",
                 action: () =>
                   this.chart(
@@ -764,8 +761,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
               },
               selectedCount === 2
             );
-            this.contextMenu.insertSubMenu( "Charts",
-              {
+            this.contextMenu.insertSubMenu( chartMenuIdx, {
                 text: "Trellis histograms",
                 action: () =>
                   this.chart(
@@ -780,8 +776,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
               },
               selectedCount >= 2 && selectedCount <= 3
             );
-            this.contextMenu.insertSubMenu( "Charts",
-              {
+            this.contextMenu.insertSubMenu( chartMenuIdx, {
                 text: "Trellis heatmaps",
                 action: () =>
                   this.chart(

--- a/web/src/main/webapp/dataViews/tableView.ts
+++ b/web/src/main/webapp/dataViews/tableView.ts
@@ -634,8 +634,8 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
             }, !this.isPrivate());
             this.contextMenu.addExpandableItem(
               {
-                text: "Charts...",
-                action: () => this.contextMenu.expandMenu("Charts..."),
+                text: "Charts",
+                action: () => null,
                 help: "List of available charts to draw. " + "",
               },
               true
@@ -720,7 +720,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                         },
                         help: "Extract a value associated with a specific key."
                     }, !this.isPrivate());
-            this.contextMenu.insertSubMenu( "Charts...",
+            this.contextMenu.insertSubMenu( "Charts",
               {
                 text: "Histogram",
                 action: () =>
@@ -736,7 +736,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
               },
               selectedCount >= 1 && selectedCount <= 2
             );
-            this.contextMenu.insertSubMenu( "Charts...",
+            this.contextMenu.insertSubMenu( "Charts",
               {
                 text: "Quartile vector",
                 action: () =>
@@ -750,7 +750,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
               },
               selectedCount == 2
             );
-            this.contextMenu.insertSubMenu( "Charts...",
+            this.contextMenu.insertSubMenu( "Charts",
               {
                 text: "Heatmap",
                 action: () =>
@@ -764,7 +764,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
               },
               selectedCount === 2
             );
-            this.contextMenu.insertSubMenu( "Charts...",
+            this.contextMenu.insertSubMenu( "Charts",
               {
                 text: "Trellis histograms",
                 action: () =>
@@ -780,7 +780,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
               },
               selectedCount >= 2 && selectedCount <= 3
             );
-            this.contextMenu.insertSubMenu( "Charts...",
+            this.contextMenu.insertSubMenu( "Charts",
               {
                 text: "Trellis heatmaps",
                 action: () =>

--- a/web/src/main/webapp/dataViews/tableView.ts
+++ b/web/src/main/webapp/dataViews/tableView.ts
@@ -632,6 +632,14 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                 action: () => this.showColumns(-1, true),
                 help: "Sort the data first on this column, in decreasing order",
             }, !this.isPrivate());
+            this.contextMenu.addExpandableItem(
+              {
+                text: "Charts...",
+                action: () => this.contextMenu.expandMenu("Charts..."),
+                help: "List of available charts to draw. " + "",
+              },
+              true
+            );
             this.contextMenu.addItem({
                 text: "Histogram",
                 action: () => this.chart(this.schema.getDescriptions(this.getSelectedColNames()),
@@ -639,16 +647,6 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                 help: "Plot the data in the selected columns as a histogram. " +
                     "Applies to one or two columns only.",
             }, selectedCount >= 1 && selectedCount <= 2);
-            this.contextMenu.addExpandableItem(
-              {
-                text: "Charts...",
-                action: () => this.contextMenu.expandMenu(),
-                help:
-                  "List of available charts to draw. " +
-                  "",
-              },
-              true
-            );
             this.contextMenu.addItem({
                 text: "Quartile vector",
                 action: () => this.chart(this.schema.getDescriptions(this.getSelectedColNames()), "QuartileVector"),
@@ -754,6 +752,7 @@ export class TableView extends TSViewBase implements IScrollTarget, OnNextK {
                         },
                         help: "Extract a value associated with a specific key."
                     }, !this.isPrivate());
+            this.contextMenu.addDummySubMenu("Charts...");
             this.contextMenu.show(e);
         };
     }

--- a/web/src/main/webapp/hillview.css
+++ b/web/src/main/webapp/hillview.css
@@ -128,7 +128,7 @@ table {
 }
 
 .tableView .empty {
-    background: #f0f0f0;
+    background: #eeeeee;
 }
 
 .tableView .empty.selected {
@@ -367,7 +367,7 @@ table.menu.topMenu {
 }
 
 table.menu td {
-    background: rgb(239, 239, 239);
+    background: rgb(224, 224, 224);
     color: rgb(0, 0, 0);
     border: 0;
     padding: 5px 10px;

--- a/web/src/main/webapp/hillview.css
+++ b/web/src/main/webapp/hillview.css
@@ -107,6 +107,7 @@ table {
     background: linear-gradient(#f9f9f9,#e4e4e4);
     border: 1px solid black;
     font-weight: bold;
+    padding: 2px 5px;
 }
 
 .tableView td.header.selected {
@@ -355,8 +356,8 @@ textarea:focus, input:focus {
 }
 
 table.menu {
-    box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.5);
-    border: 1px solid grey;
+    /* box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.5); */
+    /* border: 1px solid grey; */
     font-size:small;
     z-index: 10;
 }
@@ -382,6 +383,10 @@ td.menuItem.disabled {
 
 td.menuItem.disabled.selected {
     color: grey;
+}
+
+td.dummyMenu {
+    background: transparent !important;
 }
 
 table.menu td.selected {

--- a/web/src/main/webapp/hillview.css
+++ b/web/src/main/webapp/hillview.css
@@ -356,7 +356,6 @@ textarea:focus, input:focus {
 
 span.menuArrow {
     float: right;
-    height: 1px;
 }
 
 table.menu {

--- a/web/src/main/webapp/hillview.css
+++ b/web/src/main/webapp/hillview.css
@@ -107,7 +107,6 @@ table {
     background: linear-gradient(#f9f9f9,#e4e4e4);
     border: 1px solid black;
     font-weight: bold;
-    padding: 2px 5px;
 }
 
 .tableView td.header.selected {

--- a/web/src/main/webapp/hillview.css
+++ b/web/src/main/webapp/hillview.css
@@ -355,6 +355,11 @@ textarea:focus, input:focus {
     margin: 1px;
 }
 
+span.menuArrow {
+    float: right;
+    height: 1px;
+}
+
 table.menu {
     /* box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.5); */
     /* border: 1px solid grey; */

--- a/web/src/main/webapp/ui/menu.ts
+++ b/web/src/main/webapp/ui/menu.ts
@@ -41,156 +41,199 @@ export interface MenuItem extends BaseMenuItem {
 }
 
 abstract class BaseMenu<MI extends BaseMenuItem> implements IHtmlElement {
-    public items: MI[];
-    /**
-     * Actual html representations corresponding to the submenu items.
-     * They are stored in the same order as the items.
-     */
-    public outer: HTMLTableElement;
-    public tableBody: HTMLTableSectionElement;
-    public cells: HTMLTableDataCellElement[];
-    public selectedIndex: number;  // -1 if no item is selected
+  public items: MI[];
+  /**
+   * Actual html representations corresponding to the submenu items.
+   * They are stored in the same order as the items.
+   */
+  public outer: HTMLTableElement;
+  public tableBody: HTMLTableSectionElement;
 
-    protected constructor() {
-        this.items = [];
-        this.cells = [];
-        this.selectedIndex = -1;
-        this.outer = document.createElement("table");
-        this.outer.classList.add("menu", "hidden");
-        this.tableBody = this.outer.createTBody();
-        this.outer.onkeydown = (e) => this.keyAction(e);
+  public cells: HTMLTableDataCellElement[];
+  public trows: HTMLTableRowElement[];
+  public selectedIndex: number; // -1 if no item is selected
+
+  protected constructor() {
+    this.items = [];
+    this.cells = [];
+    this.trows = [];
+    this.selectedIndex = -1;
+    this.outer = document.createElement("table");
+    this.outer.classList.add("menu", "hidden");
+    this.tableBody = this.outer.createTBody();
+    this.outer.onkeydown = (e) => this.keyAction(e);
+  }
+
+  protected addItems(mis: MI[]): void {
+    if (mis != null) {
+      for (const mi of mis) this.addItem(mi, true);
     }
+  }
 
-    protected addItems(mis: MI[]): void {
-        if (mis != null) {
-            for (const mi of mis)
-                this.addItem(mi, true);
-        }
+  public abstract setAction(mi: MI, enabled: boolean): void;
+
+  public keyAction(e: KeyboardEvent): void {
+    if (e.code === "ArrowDown" && this.selectedIndex < this.cells.length - 1) {
+      this.select(this.selectedIndex + 1);
+    } else if (e.code === "ArrowUp" && this.selectedIndex > 0) {
+      this.select(this.selectedIndex - 1);
+    } else if (e.code === "Enter" && this.selectedIndex >= 0) {
+      // emulate a mouse click on this cell
+      this.cells[this.selectedIndex].click();
+    } else if (e.code === "Escape") {
+      this.hide();
     }
+  }
 
-    public abstract setAction(mi: MI, enabled: boolean): void;
+  /**
+   * Find the position of an item based on its text.
+   * @param text   Text string in the item.
+   */
+  public find(text: string): number {
+    for (let i = 0; i < this.items.length; i++)
+      if (this.items[i].text === text) return i;
+    return -1;
+  }
 
-    public keyAction(e: KeyboardEvent): void {
-        if (e.code === "ArrowDown" && this.selectedIndex < this.cells.length - 1) {
-            this.select(this.selectedIndex + 1);
-        } else if (e.code === "ArrowUp"  && this.selectedIndex > 0) {
-            this.select(this.selectedIndex - 1);
-        } else if (e.code === "Enter" && this.selectedIndex >= 0) {
-            // emulate a mouse click on this cell
-            this.cells[this.selectedIndex].click();
-        } else if (e.code === "Escape") {
-            this.hide();
-        }
+  public getHTMLRepresentation(): HTMLElement {
+    return this.outer;
+  }
+
+  public hide(): void {
+    this.outer.classList.add("hidden");
+  }
+
+  public getCell(mi: MI): HTMLTableCellElement {
+    const index = this.find(mi.text);
+    if (index < 0) throw new Error("Cannot find menu item");
+    return this.cells[index];
+  }
+
+  public expandMenu() {
+    this.markSelect(6, true);
+
+    const cell2 = this.trows[6].insertCell(1);
+    cell2.id = makeId("test" + "Chart-A");
+    cell2.style.textAlign = "left";
+    cell2.classList.add("menuItem");
+    cell2.textContent = "Chart-A";
+
+    const cell3 = this.trows[7].insertCell(1);
+    cell3.id = makeId("test2" + "Chart-B");
+    cell3.style.textAlign = "left";
+    cell3.classList.add("menuItem");
+    cell3.textContent = "Chart-B";
+
+    const cell4 = this.trows[8].insertCell(1);
+    cell4.id = makeId("test2" + "Chart-C");
+    cell4.style.textAlign = "left";
+    cell4.classList.add("menuItem");
+    cell4.textContent = "Chart-C";
+
+    const cell5 = this.trows[9].insertCell(1);
+    cell5.id = makeId("test2" + "Chart-D");
+    cell5.style.textAlign = "left";
+    cell5.classList.add("menuItem");
+    cell5.textContent = "Chart-D";
+  }
+
+  public addItem(mi: MI, enabled: boolean): HTMLTableDataCellElement {
+    const index = this.items.length;
+    this.items.push(mi);
+    const trow = this.tableBody.insertRow();
+    this.trows.push(trow);
+    const cell = trow.insertCell(0);
+    this.cells.push(cell);
+    if (mi.text === "---") cell.innerHTML = "<hr>";
+    else cell.textContent = mi.text;
+    cell.id = makeId(mi.text);
+    cell.style.textAlign = "left";
+    cell.classList.add("menuItem");
+    if (mi.help != null) cell.title = mi.help;
+    cell.onmouseenter = () => this.select(index);
+    cell.onmouseleave = () => this.select(-1);
+    this.enable(mi.text, enabled);
+    return cell;
+  }
+
+  public addExpandableItem(mi: MI, enabled: boolean): HTMLTableDataCellElement {
+    const index = this.items.length;
+    this.items.push(mi);
+    const trow = this.tableBody.insertRow();
+    this.trows.push(trow);
+    const cell = trow.insertCell(0);
+    this.cells.push(cell);
+    if (mi.text === "---") cell.innerHTML = "<hr>";
+    else cell.textContent = mi.text;
+    cell.id = makeId(mi.text);
+
+    cell.classList.add("expandableMenu");
+
+    cell.style.textAlign = "left";
+    cell.classList.add("menuItem");
+    if (mi.help != null) cell.title = mi.help;
+    cell.onmouseenter = () => this.select(index);
+    cell.onmouseleave = () => this.select(-1);
+    this.enable(mi.text, enabled);
+    return cell;
+  }
+
+  /**
+   * Highlight a menu item (based on mouse position on keyboard actions).
+   * @param {number} index      Index of item to highlight.
+   * @param {boolean} selected  True if the item is being selected.
+   */
+  public markSelect(index: number, selected: boolean): void {
+    if (index >= 0 && index < this.cells.length) {
+      const cell = this.cells[index];
+      if (selected) {
+        cell.classList.add("selected");
+        this.outer.focus();
+      } else {
+        cell.classList.remove("selected");
+      }
     }
+  }
 
-    /**
-     * Find the position of an item based on its text.
-     * @param text   Text string in the item.
-     */
-    public find(text: string): number {
-        for (let i = 0; i < this.items.length; i++)
-            if (this.items[i].text === text)
-                return i;
-        return -1;
-    }
+  public select(index: number): void {
+    if (this.selectedIndex >= 0) this.markSelect(this.selectedIndex, false);
+    if (index < 0 || index >= this.cells.length) index = -1; // no one
+    this.selectedIndex = index;
+    this.markSelect(this.selectedIndex, true);
+  }
 
-    public getHTMLRepresentation(): HTMLElement {
-        return this.outer;
-    }
+  public enableByIndex(index: number, enabled: boolean): void {
+    const cell = this.cells[index];
+    if (enabled) cell.classList.remove("disabled");
+    else cell.classList.add("disabled");
+    this.setAction(this.items[index], enabled);
+  }
 
-    public hide(): void {
-        this.outer.classList.add("hidden");
-    }
+  public enableItem(mi: MI, enabled: boolean): void {
+    this.enable(mi.text, enabled);
+  }
 
-    public getCell(mi: MI): HTMLTableCellElement {
-        const index = this.find(mi.text);
-        if (index < 0)
-            throw new Error("Cannot find menu item");
-        return this.cells[index];
-    }
+  /**
+   * Remove all elements from the menu.
+   */
+  public clear(): void {
+    this.tableBody.remove();
+    this.items = [];
+    this.cells = [];
+    this.tableBody = this.outer.createTBody();
+  }
 
-    public addItem(mi: MI, enabled: boolean): HTMLTableDataCellElement {
-        const index = this.items.length;
-        this.items.push(mi);
-        const trow = this.tableBody.insertRow();
-        const cell = trow.insertCell(0);
-        this.cells.push(cell);
-        if (mi.text === "---")
-            cell.innerHTML = "<hr>";
-        else
-            cell.textContent = mi.text;
-        cell.id = makeId(mi.text);
-        cell.style.textAlign = "left";
-        if (mi.help != null)
-            cell.title = mi.help;
-        cell.classList.add("menuItem");
-        cell.onmouseenter = () => this.select(index);
-        cell.onmouseleave = () => this.select(-1);
-        this.enable(mi.text, enabled);
-        return cell;
-    }
-
-    /**
-     * Highlight a menu item (based on mouse position on keyboard actions).
-     * @param {number} index      Index of item to highlight.
-     * @param {boolean} selected  True if the item is being selected.
-     */
-    public markSelect(index: number, selected: boolean): void {
-        if (index >= 0 && index < this.cells.length) {
-            const cell = this.cells[index];
-            if (selected) {
-                cell.classList.add("selected");
-                this.outer.focus();
-            } else {
-                cell.classList.remove("selected");
-            }
-        }
-    }
-
-    public select(index: number): void {
-        if (this.selectedIndex >= 0)
-            this.markSelect(this.selectedIndex, false);
-        if (index < 0 || index >= this.cells.length)
-            index = -1;  // no one
-        this.selectedIndex = index;
-        this.markSelect(this.selectedIndex, true);
-    }
-
-    public enableByIndex(index: number, enabled: boolean): void {
-        const cell = this.cells[index];
-        if (enabled)
-            cell.classList.remove("disabled");
-        else
-            cell.classList.add("disabled");
-        this.setAction(this.items[index], enabled);
-    }
-
-    public enableItem(mi: MI, enabled: boolean): void {
-        this.enable(mi.text, enabled);
-    }
-
-    /**
-     * Remove all elements from the menu.
-     */
-    public clear(): void {
-        this.tableBody.remove();
-        this.items = [];
-        this.cells = [];
-        this.tableBody = this.outer.createTBody();
-    }
-
-    /**
-     * Mark a menu item as enabled or disabled.  If disabled the action
-     * cannot be triggered.
-     * @param {string} text      Text of the item which identifies the item.
-     * @param {boolean} enabled  If true the menu item is enabled, else it is disabled.
-     */
-    public enable(text: string, enabled: boolean): void {
-        const index = this.find(text);
-        if (index < 0)
-            throw new Error("Cannot find menu item " + text);
-        this.enableByIndex(index, enabled);
-    }
+  /**
+   * Mark a menu item as enabled or disabled.  If disabled the action
+   * cannot be triggered.
+   * @param {string} text      Text of the item which identifies the item.
+   * @param {boolean} enabled  If true the menu item is enabled, else it is disabled.
+   */
+  public enable(text: string, enabled: boolean): void {
+    const index = this.find(text);
+    if (index < 0) throw new Error("Cannot find menu item " + text);
+    this.enableByIndex(index, enabled);
+  }
 }
 
 /**
@@ -249,10 +292,21 @@ export class ContextMenu extends BaseMenu<MenuItem> implements IHtmlElement {
     public setAction(mi: MenuItem, enabled: boolean): void {
         const index = this.find(mi.text);
         const cell = this.cells[index];
-        if (mi.action != null && enabled)
-            cell.onclick = () => { this.hide(); mi.action(); };
-        else
+        if (mi.action != null && enabled) {
+            if (cell.classList.contains("expandableMenu")) {
+              cell.onclick = () => {
+                // this.hide();
+                mi.action();
+              };
+            } else {
+              cell.onclick = () => {
+                this.hide();
+                mi.action();
+              };
+            }
+        } else {
             cell.onclick = () => this.hide();
+        }
     }
 }
 

--- a/web/src/main/webapp/ui/menu.ts
+++ b/web/src/main/webapp/ui/menu.ts
@@ -1,4 +1,3 @@
-import { tickStep } from "d3-array";
 /*
  * Copyright (c) 2017 VMware Inc. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
@@ -41,279 +40,157 @@ export interface MenuItem extends BaseMenuItem {
     readonly action: () => void;
 }
 
-interface subMenuCells {
-    cells: HTMLTableDataCellElement[];
-}
-
-function emptySubMenu(): subMenuCells {
-    return {
-        cells: []
-    }
-}
-
 abstract class BaseMenu<MI extends BaseMenuItem> implements IHtmlElement {
-  public items: MI[];
-  /**
-   * Actual html representations corresponding to the submenu items.
-   * They are stored in the same order as the items.
-   */
-  public outer: HTMLTableElement;
-  public tableBody: HTMLTableSectionElement;
+    public items: MI[];
+    /**
+     * Actual html representations corresponding to the submenu items.
+     * They are stored in the same order as the items.
+     */
+    public outer: HTMLTableElement;
+    public tableBody: HTMLTableSectionElement;
+    public cells: HTMLTableDataCellElement[];
+    public selectedIndex: number;  // -1 if no item is selected
 
-  public cells: HTMLTableDataCellElement[];
-  public subMenuCells: subMenuCells[];
-  public rows: HTMLTableRowElement[];
-  public selectedIndex: number; // -1 if no item is selected
-  public selectedParentMenu: number; // -1 if no item is selected
-  public selectedSubMenu: number; // -1 if no item is selected
-
-  protected constructor() {
-    this.items = [];
-    this.cells = [];
-    this.subMenuCells = [];
-    this.selectedParentMenu = -1;
-    this.rows = [];
-    this.selectedIndex = -1;
-    this.outer = document.createElement("table");
-    this.outer.classList.add("menu", "hidden");
-    this.tableBody = this.outer.createTBody();
-    this.outer.onkeydown = (e) => this.keyAction(e);
-  }
-
-  protected addItems(mis: MI[]): void {
-    if (mis != null) {
-      for (const mi of mis) this.addItem(mi, true);
-    }
-  }
-
-  public abstract setAction(mi: MI, enabled: boolean): void;
-
-  public abstract setSubMenuAction(parentIndex: number, subMenuIndex: number,
-        mi: MI, enabled: boolean): void;
-
-  public keyAction(e: KeyboardEvent): void {
-    if (e.code === "ArrowDown" && this.selectedIndex < this.cells.length - 1) {
-      this.select(this.selectedIndex + 1);
-    } else if (e.code === "ArrowUp" && this.selectedIndex > 0) {
-      this.select(this.selectedIndex - 1);
-    } else if (e.code === "Enter" && this.selectedIndex >= 0) {
-      // emulate a mouse click on this cell
-      this.cells[this.selectedIndex].click();
-    } else if (e.code === "Escape") {
-      this.hide();
-    }
-  }
-
-  /**
-   * Find the position of an item based on its text.
-   * @param text   Text string in the item.
-   */
-  public find(text: string): number {
-    for (let i = 0; i < this.items.length; i++)
-      if (this.items[i].text === text) return i;
-    return -1;
-  }
-
-  public getHTMLRepresentation(): HTMLElement {
-    return this.outer;
-  }
-
-  public hide(): void {
-    this.outer.classList.add("hidden");
-  }
-
-  public getCell(mi: MI): HTMLTableCellElement {
-    const index = this.find(mi.text);
-    if (index < 0) throw new Error("Cannot find menu item");
-    return this.cells[index];
-  }
-
-  public expandMenu(parentMenu: string) {
-    const index = this.find(parentMenu);
-    this.selectedParentMenu = index;
-    if (index < 0) throw new Error("Cannot find menu item " + parentMenu);
-    this.subMenuCells[index].cells.forEach((cell) => {
-      cell.style.display = "block";
-    });
-  }
-
-  public addItem(mi: MI, enabled: boolean): HTMLTableDataCellElement {
-    const index = this.items.length;
-    this.items.push(mi);
-    const trow = this.tableBody.insertRow();
-    this.rows.push(trow);
-    const cell = trow.insertCell(0);
-    this.cells.push(cell);
-    if (mi.text === "---") cell.innerHTML = "<hr>";
-    else cell.textContent = mi.text;
-    cell.id = makeId(mi.text);
-    cell.style.textAlign = "left";
-    cell.classList.add("menuItem");
-    if (mi.help != null) cell.title = mi.help;
-    cell.onmouseenter = () => this.select(index);
-    cell.onmouseleave = () => this.select(-1);
-    this.enable(mi.text, enabled);
-    return cell;
-  }
-
-  /**
-   * Inserting subMenu must be done in the end of all parent menu insert. If the
-   * submenu exceed the length of all main menu, we need to add dummyMenu
-   * */
-  public insertSubMenu(parentText: string, mi: MI, enabled: boolean): void {
-    const parentIndex = this.find(parentText);
-    if (parentIndex < 0) throw new Error("Cannot find menu item " + parentText);
-
-    if (this.subMenuCells[parentIndex] === undefined) {
-      this.subMenuCells[parentIndex] = emptySubMenu();
+    protected constructor() {
+        this.items = [];
+        this.cells = [];
+        this.selectedIndex = -1;
+        this.outer = document.createElement("table");
+        this.outer.classList.add("menu", "hidden");
+        this.tableBody = this.outer.createTBody();
+        this.outer.onkeydown = (e) => this.keyAction(e);
     }
 
-    const subMenuIndex = this.subMenuCells[parentIndex].cells.length;
-    const subMenuPlacementIdx = parentIndex + subMenuIndex;
-    if (this.rows[subMenuPlacementIdx] === undefined) {
-      const trow = this.tableBody.insertRow();
-      this.rows.push(trow);
-      const cell = trow.insertCell(0);
-      cell.classList.add("dummyMenu");
-    }
-    const cell = this.rows[subMenuPlacementIdx].insertCell(1);
-    cell.id = makeId(mi.text);
-    cell.style.textAlign = "left";
-    cell.style.display = "none";
-    cell.classList.add("menuItem");
-    if (enabled) cell.classList.remove("disabled");
-    else cell.classList.add("disabled");
-    if (mi.help != null) cell.title = mi.help;
-    if (mi.text === "---") cell.innerHTML = "<hr>";
-    else cell.textContent = mi.text;
-
-    var subIndex = this.subMenuCells[parentIndex].cells.length;
-    this.subMenuCells[parentIndex].cells.push(cell);
-    cell.onmouseenter = () => this.selectSubMenu(parentIndex, subIndex);
-    cell.onmouseleave = () => this.selectSubMenu(parentIndex, -1);
-    this.setSubMenuAction(parentIndex, subMenuIndex, mi, enabled);
-  }
-
-  public addExpandableItem(mi: MI, enabled: boolean): HTMLTableDataCellElement {
-    const cell = this.addItem(mi, enabled);
-    cell.classList.add("expandableMenu");
-
-    const arrow = document.createElement("span");
-    arrow.textContent = "▸";
-    arrow.style.float = "right";
-    cell.appendChild(arrow);
-
-    // reset the action so that it doesn't hide() after click
-    this.enable(mi.text, enabled);
-    return cell;
-  }
-
-  /**
-   * Highlight a menu item (based on mouse position on keyboard actions).
-   * @param {number} index      Index of item to highlight.
-   * @param {boolean} selected  True if the item is being selected.
-   */
-  public markSelect(index: number, selected: boolean): void {
-    if (index >= 0 && index < this.cells.length) {
-      const cell = this.cells[index];
-      if (selected) {
-        // remove submenu if the parentMenu is not selected
-        if (this.selectedParentMenu != -1 && index != this.selectedParentMenu) {
-          this.hideAllSubMenu();
+    protected addItems(mis: MI[]): void {
+        if (mis != null) {
+            for (const mi of mis)
+                this.addItem(mi, true);
         }
-        // Show subMenu when parent menu is active
-        if (cell.classList.contains("expandableMenu")) {
-          this.expandMenu(cell.firstChild.textContent);
+    }
+
+    public abstract setAction(mi: MI, enabled: boolean): void;
+
+    public keyAction(e: KeyboardEvent): void {
+        if (e.code === "ArrowDown" && this.selectedIndex < this.cells.length - 1) {
+            this.select(this.selectedIndex + 1);
+        } else if (e.code === "ArrowUp"  && this.selectedIndex > 0) {
+            this.select(this.selectedIndex - 1);
+        } else if (e.code === "Enter" && this.selectedIndex >= 0) {
+            // emulate a mouse click on this cell
+            this.cells[this.selectedIndex].click();
+        } else if (e.code === "Escape") {
+            this.hide();
         }
-        cell.classList.add("selected");
-        this.outer.focus();
-      } else {
-        cell.classList.remove("selected");
-      }
     }
-  }
 
-  public select(index: number): void {
-    if (this.selectedIndex >= 0) this.markSelect(this.selectedIndex, false);
-    if (index < 0 || index >= this.cells.length) index = -1; // no one
-    this.selectedIndex = index;
-    this.markSelect(this.selectedIndex, true);
-  }
-
-  public enableByIndex(index: number, enabled: boolean): void {
-    const cell = this.cells[index];
-    if (enabled) cell.classList.remove("disabled");
-    else cell.classList.add("disabled");
-    this.setAction(this.items[index], enabled);
-  }
-
-  public hideAllSubMenu(): void {
-    this.subMenuCells[this.selectedParentMenu].cells.forEach((cell) => {
-      cell.style.display = "none";
-      cell.classList.remove("selected");
-    });
-    this.markSelect(this.selectedParentMenu, false);
-    this.selectedParentMenu = -1;
-    this.selectedSubMenu = -1;
-  }
-
-  public markSelectSubMenu(index: number, selected: boolean): void {
-    if (
-      index >= 0 &&
-      index < this.subMenuCells[this.selectedParentMenu].cells.length
-    ) {
-      const cell = this.subMenuCells[this.selectedParentMenu].cells[index];
-      if (selected) {
-        cell.classList.add("selected");
-        this.outer.focus();
-      } else {
-        cell.classList.remove("selected");
-      }
+    /**
+     * Find the position of an item based on its text.
+     * @param text   Text string in the item.
+     */
+    public find(text: string): number {
+        for (let i = 0; i < this.items.length; i++)
+            if (this.items[i].text === text)
+                return i;
+        return -1;
     }
-  }
 
-  public selectSubMenu(parentIndex: number, subIndex: number): void {
-    if (subIndex == -1) {
-      this.markSelectSubMenu(this.selectedSubMenu, false);
-    } else {
-      this.markSelect(parentIndex, true);
-      if (
-        subIndex < 0 ||
-        subIndex >= this.subMenuCells[parentIndex].cells.length
-      )
-        subIndex = -1; // no one
-      this.selectedSubMenu = subIndex;
-      this.markSelectSubMenu(this.selectedSubMenu, true);
+    public getHTMLRepresentation(): HTMLElement {
+        return this.outer;
     }
-  }
 
-  public enableItem(mi: MI, enabled: boolean): void {
-    this.enable(mi.text, enabled);
-  }
+    public hide(): void {
+        this.outer.classList.add("hidden");
+    }
 
-  /**
-   * Remove all elements from the menu.
-   */
-  public clear(): void {
-    this.tableBody.remove();
-    this.items = [];
-    this.cells = [];
-    this.rows = [];
-    this.subMenuCells = [];
-    this.tableBody = this.outer.createTBody();
-  }
+    public getCell(mi: MI): HTMLTableCellElement {
+        const index = this.find(mi.text);
+        if (index < 0)
+            throw new Error("Cannot find menu item");
+        return this.cells[index];
+    }
 
-  /**
-   * Mark a menu item as enabled or disabled.  If disabled the action
-   * cannot be triggered.
-   * @param {string} text      Text of the item which identifies the item.
-   * @param {boolean} enabled  If true the menu item is enabled, else it is disabled.
-   */
-  public enable(text: string, enabled: boolean): void {
-    const index = this.find(text);
-    if (index < 0) throw new Error("Cannot find menu item " + text);
-    this.enableByIndex(index, enabled);
-  }
+    public addItem(mi: MI, enabled: boolean): HTMLTableDataCellElement {
+        const index = this.items.length;
+        this.items.push(mi);
+        const trow = this.tableBody.insertRow();
+        const cell = trow.insertCell(0);
+        this.cells.push(cell);
+        if (mi.text === "---")
+            cell.innerHTML = "<hr>";
+        else
+            cell.textContent = mi.text;
+        cell.id = makeId(mi.text);
+        cell.style.textAlign = "left";
+        if (mi.help != null)
+            cell.title = mi.help;
+        cell.classList.add("menuItem");
+        cell.onmouseenter = () => this.select(index);
+        cell.onmouseleave = () => this.select(-1);
+        this.enable(mi.text, enabled);
+        return cell;
+    }
+
+    /**
+     * Highlight a menu item (based on mouse position on keyboard actions).
+     * @param {number} index      Index of item to highlight.
+     * @param {boolean} selected  True if the item is being selected.
+     */
+    public markSelect(index: number, selected: boolean): void {
+        if (index >= 0 && index < this.cells.length) {
+            const cell = this.cells[index];
+            if (selected) {
+                cell.classList.add("selected");
+                this.outer.focus();
+            } else {
+                cell.classList.remove("selected");
+            }
+        }
+    }
+
+    public select(index: number): void {
+        if (this.selectedIndex >= 0)
+            this.markSelect(this.selectedIndex, false);
+        if (index < 0 || index >= this.cells.length)
+            index = -1;  // no one
+        this.selectedIndex = index;
+        this.markSelect(this.selectedIndex, true);
+    }
+
+    public enableByIndex(index: number, enabled: boolean): void {
+        const cell = this.cells[index];
+        if (enabled)
+            cell.classList.remove("disabled");
+        else
+            cell.classList.add("disabled");
+        this.setAction(this.items[index], enabled);
+    }
+
+    public enableItem(mi: MI, enabled: boolean): void {
+        this.enable(mi.text, enabled);
+    }
+
+    /**
+     * Remove all elements from the menu.
+     */
+    public clear(): void {
+        this.tableBody.remove();
+        this.items = [];
+        this.cells = [];
+        this.tableBody = this.outer.createTBody();
+    }
+
+    /**
+     * Mark a menu item as enabled or disabled.  If disabled the action
+     * cannot be triggered.
+     * @param {string} text      Text of the item which identifies the item.
+     * @param {boolean} enabled  If true the menu item is enabled, else it is disabled.
+     */
+    public enable(text: string, enabled: boolean): void {
+        const index = this.find(text);
+        if (index < 0)
+            throw new Error("Cannot find menu item " + text);
+        this.enableByIndex(index, enabled);
+    }
 }
 
 /**
@@ -372,34 +249,10 @@ export class ContextMenu extends BaseMenu<MenuItem> implements IHtmlElement {
     public setAction(mi: MenuItem, enabled: boolean): void {
         const index = this.find(mi.text);
         const cell = this.cells[index];
-        if (mi.action != null && enabled) {
-            if (cell.classList.contains("expandableMenu")) {
-              cell.onclick = () => {
-                // this.hide();
-                mi.action();
-              };
-            } else {
-              cell.onclick = () => {
-                this.hide();
-                mi.action();
-              };
-            }
-        } else {
+        if (mi.action != null && enabled)
+            cell.onclick = () => { this.hide(); mi.action(); };
+        else
             cell.onclick = () => this.hide();
-        }
-    }
-
-    public setSubMenuAction(parentIndex: number, subMenuIndex: number,
-        mi: MenuItem, enabled: boolean): void {
-        const cell = this.subMenuCells[parentIndex].cells[subMenuIndex];
-        if (mi.action != null && enabled) {
-            cell.onclick = () => {
-                this.hide();
-                mi.action();
-            };
-        } else {
-            cell.onclick = () => this.hide();
-        }
     }
 }
 
@@ -428,11 +281,6 @@ export class SubMenu extends BaseMenu<MenuItem> implements IHtmlElement {
             cell.onclick = (e: MouseEvent) => { e.stopPropagation(); this.hide(); mi.action(); };
         else
             cell.onclick = (e: MouseEvent) => { e.stopPropagation(); this.hide(); };
-    }
-
-    public setSubMenuAction(parentIndex: number, subMenuIndex: number,
-        mi: MenuItem, enabled: boolean): void {
-        throw new Error("Method not implemented.");
     }
 }
 
@@ -491,11 +339,6 @@ export class TopMenu extends BaseMenu<TopMenuItem> {
             cell.classList.remove("selected");
             this.hideSubMenus();
         };
-    }
-
-    public setSubMenuAction(parentIndex: number, subMenuIndex: number,
-        mi: TopMenuItem, enabled: boolean): void {
-        throw new Error("Method not implemented.");
     }
 
     public getHTMLRepresentation(): HTMLElement {

--- a/web/src/main/webapp/ui/menu.ts
+++ b/web/src/main/webapp/ui/menu.ts
@@ -202,7 +202,7 @@ abstract class BaseMenu<MI extends BaseMenuItem> implements IHtmlElement {
 
         const arrow = document.createElement("span");
         arrow.textContent = "▸";
-        arrow.style.float = "right";
+        arrow.classList.add("menuArrow");
         cell.appendChild(arrow);
 
         // reset the action so that it doesn't hide() after click
@@ -376,10 +376,7 @@ export class ContextMenu extends BaseMenu<MenuItem> implements IHtmlElement {
         const cell = this.cells[index];
         if (mi.action != null && enabled) {
             if (cell.classList.contains("expandableMenu")) {
-              cell.onclick = () => {
-                // this.hide();
-                mi.action();
-              };
+              // no operation because expandableMenu only expand its submenus
             } else {
               cell.onclick = () => {
                 this.hide();

--- a/web/src/main/webapp/ui/menu.ts
+++ b/web/src/main/webapp/ui/menu.ts
@@ -192,10 +192,10 @@ abstract class BaseMenu<MI extends BaseMenuItem> implements IHtmlElement {
     const index = this.find(parentText);
     if (index < 0) throw new Error("Cannot find menu item " + parentText);
 
-    this.insertSubMenu(index, index + 0, "Chart-A");
-    this.insertSubMenu(index, index + 1, "Chart-B");
-    this.insertSubMenu(index, index + 2, "Chart-C");
-    this.insertSubMenu(index, index + 3, "Chart-D");
+    this.insertSubMenu(index, index + 0, parentText + "-A");
+    this.insertSubMenu(index, index + 1, parentText + "-B");
+    this.insertSubMenu(index, index + 2, parentText + "-C");
+    this.insertSubMenu(index, index + 3, parentText + "-D");
   }
 
   public addExpandableItem(mi: MI, enabled: boolean): HTMLTableDataCellElement {
@@ -224,6 +224,10 @@ abstract class BaseMenu<MI extends BaseMenuItem> implements IHtmlElement {
         // remove submenu if the parentMenu is not selected
         if ( this.selectedParentMenu != -1 && index != this.selectedParentMenu) {
             this.hideAllSubMenu();
+        }
+        // Show subMenu when parent menu is active
+        if (cell.classList.contains("expandableMenu")) {
+            this.expandMenu(cell.firstChild.textContent);
         }
         cell.classList.add("selected");
         this.outer.focus();

--- a/web/src/main/webapp/ui/menu.ts
+++ b/web/src/main/webapp/ui/menu.ts
@@ -87,9 +87,6 @@ abstract class BaseMenu<MI extends BaseMenuItem> implements IHtmlElement {
 
     public abstract setAction(mi: MI, enabled: boolean): void;
 
-    public abstract setSubMenuAction(parentIndex: number, subMenuIndex: number,
-            mi: MI, enabled: boolean): void;
-
     public keyAction(e: KeyboardEvent): void {
         if (e.code === "ArrowDown" && this.selectedIndex < this.cells.length - 1) {
             this.select(this.selectedIndex + 1);
@@ -158,42 +155,6 @@ abstract class BaseMenu<MI extends BaseMenuItem> implements IHtmlElement {
         cell.onmouseleave = () => this.select(-1);
         this.enable(mi.text, enabled);
         return cell;
-    }
-
-    /**
-     * Inserting subMenu must be done in the end of all parent menu insert. If the
-     * submenu exceed the length of all main menu, we need to add dummyMenu
-     * */
-    public insertSubMenu(parentText: string, mi: MI, enabled: boolean): void {
-        const parentIndex = this.find(parentText);
-        if (parentIndex < 0) throw new Error("Cannot find menu item " + parentText);
-        if (this.subMenuCells[parentIndex] === undefined)
-            this.subMenuCells[parentIndex] = emptySubMenu();
-
-        const subMenuIndex = this.subMenuCells[parentIndex].cells.length;
-        const subMenuPlacementIdx = parentIndex + subMenuIndex;
-        if (this.rows[subMenuPlacementIdx] === undefined) {
-            const trow = this.tableBody.insertRow();
-            this.rows.push(trow);
-            const cell = trow.insertCell(0);
-            cell.classList.add("dummyMenu");
-        }
-        const cell = this.rows[subMenuPlacementIdx].insertCell(1);
-        cell.id = makeId(mi.text);
-        cell.style.textAlign = "left";
-        cell.style.display = "none";
-        cell.classList.add("menuItem");
-        if (enabled) cell.classList.remove("disabled");
-        else cell.classList.add("disabled");
-        if (mi.help != null) cell.title = mi.help;
-        if (mi.text === "---") cell.innerHTML = "<hr>";
-        else cell.textContent = mi.text;
-
-        var subIndex = this.subMenuCells[parentIndex].cells.length;
-        this.subMenuCells[parentIndex].cells.push(cell);
-        cell.onmouseenter = () => this.selectSubMenu(parentIndex, subIndex);
-        cell.onmouseleave = () => this.selectSubMenu(parentIndex, -1);
-        this.setSubMenuAction(parentIndex, subMenuIndex, mi, enabled);
     }
 
     public addExpandableItem(mi: MI, enabled: boolean): HTMLTableDataCellElement {
@@ -388,6 +349,42 @@ export class ContextMenu extends BaseMenu<MenuItem> implements IHtmlElement {
         }
     }
 
+    /**
+     * Inserting subMenu must be done in the end of all parent menu insert. If the
+     * submenu exceed the length of all main menu, we need to add dummyMenu
+     * */
+    public insertSubMenu(parentText: string, mi: MenuItem, enabled: boolean): void {
+        const parentIndex = this.find(parentText);
+        if (parentIndex < 0) throw new Error("Cannot find menu item " + parentText);
+        if (this.subMenuCells[parentIndex] === undefined)
+            this.subMenuCells[parentIndex] = emptySubMenu();
+
+        const subMenuIndex = this.subMenuCells[parentIndex].cells.length;
+        const subMenuPlacementIdx = parentIndex + subMenuIndex;
+        if (this.rows[subMenuPlacementIdx] === undefined) {
+            const trow = this.tableBody.insertRow();
+            this.rows.push(trow);
+            const cell = trow.insertCell(0);
+            cell.classList.add("dummyMenu");
+        }
+        const cell = this.rows[subMenuPlacementIdx].insertCell(1);
+        cell.id = makeId(mi.text);
+        cell.style.textAlign = "left";
+        cell.style.display = "none";
+        cell.classList.add("menuItem");
+        if (enabled) cell.classList.remove("disabled");
+        else cell.classList.add("disabled");
+        if (mi.help != null) cell.title = mi.help;
+        if (mi.text === "---") cell.innerHTML = "<hr>";
+        else cell.textContent = mi.text;
+
+        var subIndex = this.subMenuCells[parentIndex].cells.length;
+        this.subMenuCells[parentIndex].cells.push(cell);
+        cell.onmouseenter = () => this.selectSubMenu(parentIndex, subIndex);
+        cell.onmouseleave = () => this.selectSubMenu(parentIndex, -1);
+        this.setSubMenuAction(parentIndex, subMenuIndex, mi, enabled);
+    }
+
     public setSubMenuAction(parentIndex: number, subMenuIndex: number,
         mi: MenuItem, enabled: boolean): void {
         const cell = this.subMenuCells[parentIndex].cells[subMenuIndex];
@@ -427,11 +424,6 @@ export class SubMenu extends BaseMenu<MenuItem> implements IHtmlElement {
             cell.onclick = (e: MouseEvent) => { e.stopPropagation(); this.hide(); mi.action(); };
         else
             cell.onclick = (e: MouseEvent) => { e.stopPropagation(); this.hide(); };
-    }
-
-    public setSubMenuAction(parentIndex: number, subMenuIndex: number,
-        mi: MenuItem, enabled: boolean): void {
-        throw new Error("Method not implemented.");
     }
 }
 
@@ -490,11 +482,6 @@ export class TopMenu extends BaseMenu<TopMenuItem> {
             cell.classList.remove("selected");
             this.hideSubMenus();
         };
-    }
-
-    public setSubMenuAction(parentIndex: number, subMenuIndex: number,
-        mi: TopMenuItem, enabled: boolean): void {
-        throw new Error("Method not implemented.");
     }
 
     public getHTMLRepresentation(): HTMLElement {

--- a/web/src/main/webapp/ui/menu.ts
+++ b/web/src/main/webapp/ui/menu.ts
@@ -135,7 +135,7 @@ abstract class BaseMenu<MI extends BaseMenuItem> implements IHtmlElement {
         this.selectedParentMenu = index;
         if (index < 0) throw new Error("Cannot find menu item " + parentMenu);
         this.subMenuCells[index].cells.forEach((cell) => {
-            cell.style.display = "block";
+            cell.style.display = "table-cell";
         });
     }
 

--- a/web/src/main/webapp/ui/menu.ts
+++ b/web/src/main/webapp/ui/menu.ts
@@ -66,13 +66,11 @@ abstract class BaseMenu<MI extends BaseMenuItem> implements IHtmlElement {
   public selectedIndex: number; // -1 if no item is selected
   public selectedParentMenu: number; // -1 if no item is selected
   public selectedSubMenu: number; // -1 if no item is selected
-  public subMenuActive: boolean; // -1 if no item is selected
 
   protected constructor() {
     this.items = [];
     this.cells = [];
     this.subMenuCells = [];
-    this.subMenuActive = false;
     this.selectedParentMenu = -1;
     this.rows = [];
     this.selectedIndex = -1;
@@ -137,7 +135,6 @@ abstract class BaseMenu<MI extends BaseMenuItem> implements IHtmlElement {
     this.subMenuCells[index].cells.forEach((cell) => {
       cell.style.display = "block";
     });
-    this.subMenuActive = true;
   }
 
   public addItem(mi: MI, enabled: boolean): HTMLTableDataCellElement {

--- a/web/src/main/webapp/ui/menu.ts
+++ b/web/src/main/webapp/ui/menu.ts
@@ -514,4 +514,4 @@ export class TopMenu extends BaseMenu<TopMenuItem> {
                 return item.subMenu;
         return null;
     }
-} 
+}

--- a/web/src/main/webapp/ui/menu.ts
+++ b/web/src/main/webapp/ui/menu.ts
@@ -157,20 +157,6 @@ abstract class BaseMenu<MI extends BaseMenuItem> implements IHtmlElement {
         return cell;
     }
 
-    public addExpandableItem(mi: MI, enabled: boolean): HTMLTableDataCellElement {
-        const cell = this.addItem(mi, enabled);
-        cell.classList.add("expandableMenu");
-
-        const arrow = document.createElement("span");
-        arrow.textContent = "▸";
-        arrow.classList.add("menuArrow");
-        cell.appendChild(arrow);
-
-        // reset the action so that it doesn't hide() after click
-        this.enable(mi.text, enabled);
-        return cell;
-    }
-
     /**
      * Highlight a menu item (based on mouse position on keyboard actions).
      * @param {number} index      Index of item to highlight.
@@ -349,13 +335,25 @@ export class ContextMenu extends BaseMenu<MenuItem> implements IHtmlElement {
         }
     }
 
+    public addExpandableItem(mi: MenuItem, enabled: boolean): number {
+        const cell = this.addItem(mi, enabled);
+        cell.classList.add("expandableMenu");
+
+        const arrow = document.createElement("span");
+        arrow.textContent = "▸";
+        arrow.classList.add("menuArrow");
+        cell.appendChild(arrow);
+
+        // reset the action so that it doesn't hide() after click
+        this.enable(mi.text, enabled);
+        return this.cells.length - 1;
+    }
+
     /**
      * Inserting subMenu must be done in the end of all parent menu insert. If the
      * submenu exceed the length of all main menu, we need to add dummyMenu
      * */
-    public insertSubMenu(parentText: string, mi: MenuItem, enabled: boolean): void {
-        const parentIndex = this.find(parentText);
-        if (parentIndex < 0) throw new Error("Cannot find menu item " + parentText);
+    public insertSubMenu(parentIndex: number, mi: MenuItem, enabled: boolean): void {
         if (this.subMenuCells[parentIndex] === undefined)
             this.subMenuCells[parentIndex] = emptySubMenu();
 

--- a/web/src/main/webapp/ui/menu.ts
+++ b/web/src/main/webapp/ui/menu.ts
@@ -147,7 +147,6 @@ abstract class BaseMenu<MI extends BaseMenuItem> implements IHtmlElement {
     this.rows.push(trow);
     const cell = trow.insertCell(0);
     this.cells.push(cell);
-    this.subMenuCells[index] = emptySubMenu();
     if (mi.text === "---") cell.innerHTML = "<hr>";
     else cell.textContent = mi.text;
     cell.id = makeId(mi.text);


### PR DESCRIPTION
This PR adds two interfaces to create a submenu:
1. this.contextMenu.addExpandableItem
This is similar to addItem, the code will only add `expandableMenu` as an additional class to that item.
2. this.contextMenu.insertSubMenu(parentMenu, mi, enabled)
This will create a submenu item of the parentMenu. 