### PR TITLE
Fix the problem on loading Federated Menu

### DIFF
--- a/web/src/main/webapp/initialObject.ts
+++ b/web/src/main/webapp/initialObject.ts
@@ -218,7 +218,8 @@ export class InitialObject extends RemoteObject {
         rr.invoke(observer);
     }
 
-    public loadFederatedDBTable(conn: any, db: String, loadMenuPage: FullPage): void {
+    public loadFederatedDBTable(conn: JdbcConnectionInformation | CassandraConnectionInfo,
+            db: String, loadMenuPage: FullPage): void {
         switch (db) {
             case "mysql":
             case "impala":

--- a/web/src/main/webapp/initialObject.ts
+++ b/web/src/main/webapp/initialObject.ts
@@ -218,11 +218,15 @@ export class InitialObject extends RemoteObject {
         rr.invoke(observer);
     }
 
-    public loadFederatedDBTable(jdbcConn: JdbcConnectionInformation, cassConn: CassandraConnectionInfo, loadMenuPage: FullPage): void {
-        if (jdbcConn.databaseKind == "cassandra") {
-            this.loadCassandraFiles(cassConn, loadMenuPage);
-        } else {
-            this.loadDBTable(jdbcConn, loadMenuPage);
+    public loadFederatedDBTable(conn: any, db: String, loadMenuPage: FullPage): void {
+        switch (db) {
+            case "mysql":
+            case "impala":
+                this.loadDBTable(<JdbcConnectionInformation>conn, loadMenuPage);
+                break;
+            case "cassandra":
+                this.loadCassandraFiles(<CassandraConnectionInfo>conn, loadMenuPage);
+                break;
         }
     }
 }

--- a/web/src/main/webapp/loadView.ts
+++ b/web/src/main/webapp/loadView.ts
@@ -238,12 +238,8 @@ export class LoadView extends RemoteObject implements IDataView {
                 text: "Federated DB tables...",
                 action: () => {
                     const dialog = new DBDialog(true);
-                    const connection = dialog.getCassandraConnection();
-                    if (connection == null) {
-                        this.page.reportError("Not a valid connection");
-                        return;
-                    }
-                    dialog.setAction(() => this.init.loadFederatedDBTable(dialog.getConnection(), connection, this.page));
+                    dialog.setAction(() => this.init.loadFederatedDBTable(dialog.getJdbcConnection(),
+                        dialog.getCassandraConnection(), this.page));
                     dialog.show();
                 },
                 help: "A set of database tables residing in databases on each worker machine."
@@ -255,7 +251,7 @@ export class LoadView extends RemoteObject implements IDataView {
                 text: "Local DB table...",
                 action: () => {
                     const dialog = new DBDialog(false);
-                    dialog.setAction(() => this.init.loadSimpleDBTable(dialog.getConnection(), this.page));
+                    dialog.setAction(() => this.init.loadSimpleDBTable(dialog.getJdbcConnection(), this.page));
                     dialog.show();
                 },
                 help: "A database table in a single database."
@@ -657,7 +653,7 @@ class DBDialog extends Dialog {
         }
     }
 
-    public getConnection(): JdbcConnectionInformation {
+    public getJdbcConnection(): JdbcConnectionInformation {
         return {
             host: this.getFieldValue("host"),
             port: this.getFieldValueAsNumber("port") ?? 0,
@@ -671,21 +667,18 @@ class DBDialog extends Dialog {
     }
 
     public getCassandraConnection(): CassandraConnectionInfo | null {
-        if (this.getFieldValue("databaseKind") != "cassandra")
-            return null;
-        else
-            return {
-                host: this.getFieldValue("host"),
-                port: this.getFieldValueAsNumber("port") ?? 0,
-                database: this.getFieldValue("database"),
-                table: this.getFieldValue("table"),
-                user: this.getFieldValue("user"),
-                password: this.getFieldValue("password"),
-                databaseKind: this.getFieldValue("databaseKind"),
-                lazyLoading: true,
-                jmxPort: this.getFieldValueAsNumber("jmxPort") ?? 0,
-                cassandraRootDir: this.getFieldValue("dbDir"),
-            };
+        return {
+            host: this.getFieldValue("host"),
+            port: this.getFieldValueAsNumber("port") ?? 0,
+            database: this.getFieldValue("database"),
+            table: this.getFieldValue("table"),
+            user: this.getFieldValue("user"),
+            password: this.getFieldValue("password"),
+            databaseKind: this.getFieldValue("databaseKind"),
+            lazyLoading: true,
+            jmxPort: this.getFieldValueAsNumber("jmxPort") ?? 0,
+            cassandraRootDir: this.getFieldValue("dbDir"),
+        };
     }
 
     public hideInputField(fieldName: string, field?: HTMLElement) {

--- a/web/src/main/webapp/loadView.ts
+++ b/web/src/main/webapp/loadView.ts
@@ -238,8 +238,7 @@ export class LoadView extends RemoteObject implements IDataView {
                 text: "Federated DB tables...",
                 action: () => {
                     const dialog = new DBDialog(true);
-                    dialog.setAction(() => this.init.loadFederatedDBTable(dialog.getJdbcConnection(),
-                        dialog.getCassandraConnection(), this.page));
+                    dialog.setAction(() => this.init.loadFederatedDBTable(dialog.getDBConnection(), dialog.getDatabaseKind() , this.page));
                     dialog.show();
                 },
                 help: "A set of database tables residing in databases on each worker machine."
@@ -653,6 +652,21 @@ class DBDialog extends Dialog {
         }
     }
 
+    public getDatabaseKind(): String {
+        return this.getFieldValue("databaseKind");
+    }
+
+    public getDBConnection(): any {
+        const db = this.getFieldValue("databaseKind");
+        switch (db) {
+            case "mysql":
+            case "impala":
+                return this.getJdbcConnection();
+            case "cassandra":
+                return this.getCassandraConnection();
+        }
+    }
+
     public getJdbcConnection(): JdbcConnectionInformation {
         return {
             host: this.getFieldValue("host"),
@@ -666,7 +680,7 @@ class DBDialog extends Dialog {
         };
     }
 
-    public getCassandraConnection(): CassandraConnectionInfo | null {
+    public getCassandraConnection(): CassandraConnectionInfo {
         return {
             host: this.getFieldValue("host"),
             port: this.getFieldValueAsNumber("port") ?? 0,


### PR DESCRIPTION
Originally, the federated menu won't load, due this logic:
```
const connection = dialog.getCassandraConnection();
if (connection == null) {
    this.page.reportError("Not a valid connection");
    return;
}
```
The `dialog.getCassandraConnection()` will always return `null`, thus it displays  `Not a valid connection`. This `getCassandraConnection()` will be executed when the user presses the `confirm` button. Therefore, I remove the null checking, and make it similar to ` getJdbcConnection()`.

In the next PR, I will add Hive connection dialog on top of this logic. 