### PR TITLE
Read from Cassandra's snapshot

### DIFF
--- a/data/sstable/loadCassandraDB.sh
+++ b/data/sstable/loadCassandraDB.sh
@@ -15,5 +15,7 @@ ${CASSANDRA_INSTALLATION_DIR}/bin/cqlsh --file ${SAVEDIR}/cassdb.cql
 # Force Compaction to put the data into sstable
 ${CASSANDRA_INSTALLATION_DIR}/bin/nodetool flush
 ${CASSANDRA_INSTALLATION_DIR}/bin/nodetool compact cassdb
+${CASSANDRA_INSTALLATION_DIR}/bin/nodetool snapshot myTestSnapshot cassdb
+
 ${CASSANDRA_INSTALLATION_DIR}/bin/nodetool -h localhost -p 7199 clearsnapshot
 rm -f flights_data.csv

--- a/platform/src/main/java/org/hillview/storage/CassandraConnectionInfo.java
+++ b/platform/src/main/java/org/hillview/storage/CassandraConnectionInfo.java
@@ -25,6 +25,10 @@ public class CassandraConnectionInfo extends JdbcConnectionInformation {
 
     /** Port for establishing probe connection */
     public int jmxPort;
+
+    /** The target snapshot to load */
+    public String snapshotName;
+
     /**
      * Local Cassandra installation directory (can be found at
      * bin/install-cassandra.sh)
@@ -36,6 +40,7 @@ public class CassandraConnectionInfo extends JdbcConnectionInformation {
         StringBuilder sb = new StringBuilder(super.toString());
         sb.append("  jmxPort : " + this.jmxPort + "\n");
         sb.append("  cassandraRootDir : " + this.cassandraRootDir + "\n");
+        sb.append("  snapshotName : " + this.snapshotName + "\n");
         return sb.toString();
     }
 }

--- a/platform/src/test/java/org/hillview/test/storage/SSTableTest.java
+++ b/platform/src/test/java/org/hillview/test/storage/SSTableTest.java
@@ -54,6 +54,7 @@ public class SSTableTest extends BaseTest {
         conn.user = "";
         conn.password = "";
         conn.lazyLoading = true;
+        conn.snapshotName = "myTestSnapshot";
         return conn;
     }
 
@@ -158,6 +159,22 @@ public class SSTableTest extends BaseTest {
         }
         List<CassTable> storedTable = db.getStoredTableInfo();
         Assert.assertTrue(storedTable.toString().contains("cassdb: [ test counter flights users]"));
+    }
+
+    @Test
+    public void testDiscoverSnapshot() {
+        CassandraConnectionInfo conn;
+        CassandraDatabase db;
+        try {
+            // Connecting to Cassandra node and get some data
+            conn = this.getConnectionInfo();
+            db = new CassandraDatabase(conn);
+        } catch (Exception e) {
+            // this will fail if local Cassandra is not running, but we don't want to fail the test.
+            this.ignoringException("Failed connecting to local cassandra", e);
+            return;
+        }
+        Assert.assertTrue(db.getSSTablePath().get(0).contains(conn.snapshotName));
     }
 
     /** Shows the interaction between CassandraDatabase.java and CassandraSSTableLoader.java */

--- a/web/src/main/webapp/javaBridge.ts
+++ b/web/src/main/webapp/javaBridge.ts
@@ -154,6 +154,7 @@ export interface JdbcConnectionInformation {
 export interface CassandraConnectionInfo extends JdbcConnectionInformation {
     jmxPort: number;
     cassandraRootDir: string;
+    snapshotName: string;
 }
 
 export type DataKinds = "csv" | "orc" | "parquet" | "json" | "hillviewlog" | "db" | "genericlog" | "sstable";

--- a/web/src/main/webapp/loadView.ts
+++ b/web/src/main/webapp/loadView.ts
@@ -613,7 +613,10 @@ class DBDialog extends Dialog {
         if (isFederated) {
             const jmxPort = this.addTextField("jmxPort", "JMX Port", FieldKind.Integer, null,
                 "Cassandra's JMX port to connect to server-side tools.");
+            const snapshotName = this.addTextField("snapshotName", "Snapshot Name", FieldKind.String, null,
+                "The target snapshot to load.");
             this.hideInputField("jmxPort", jmxPort);
+            this.hideInputField("snapshotName", snapshotName);
         }
         const database = this.addTextField("database", "Database", FieldKind.String, null,
             "Name of database to load.");
@@ -648,6 +651,7 @@ class DBDialog extends Dialog {
                 this.setFieldValue("jmxPort", "7199");
                 this.showInputField("jmxPort");
                 this.showInputField("dbDir");
+                this.showInputField("snapshotName");
                 break;
         }
     }
@@ -692,6 +696,7 @@ class DBDialog extends Dialog {
             lazyLoading: true,
             jmxPort: this.getFieldValueAsNumber("jmxPort") ?? 0,
             cassandraRootDir: this.getFieldValue("dbDir"),
+            snapshotName: this.getFieldValue("snapshotName"),
         };
     }
 


### PR DESCRIPTION
This PR contains the backend code for loading Cassandra Snapshot. The UI is not yet updated, because the code depends on the other PR (https://github.com/vmware/hillview/pull/675). 

I added some codes about discovering the snapshot directory and validating the snapshot name + snapshot folders.  
The (platform) unit test should be working as long as you rerun `loadCassandraDB.sh` which will create the snapshot with this command `${CASSANDRA_INSTALLATION_DIR}/bin/nodetool snapshot myTestSnapshot cassdb`