### PR TITLE
Reimplemented rename to simplify front-end

### DIFF
--- a/platform/src/main/java/org/hillview/maps/CreateColumnMap.java
+++ b/platform/src/main/java/org/hillview/maps/CreateColumnMap.java
@@ -27,7 +27,7 @@ import java.io.Serializable;
 /**
  * This map creates a new column by applying the function to each element in an input column.
  */
-public abstract class CreateColumnMap extends AppendColumnMap {
+public abstract class CreateColumnMap extends AppendOrReplaceColumnMap {
     static final long serialVersionUID = 1;
 
     static class Info implements Serializable {
@@ -45,7 +45,7 @@ public abstract class CreateColumnMap extends AppendColumnMap {
     private final Info info;
 
     CreateColumnMap(Info info) {
-        super(info.outputColumn, info.outputIndex);
+        super(info.outputIndex);
         this.info = info;
     }
 
@@ -55,7 +55,7 @@ public abstract class CreateColumnMap extends AppendColumnMap {
     @Override
     public IColumn createColumn(ITable table) {
         IColumn col = table.getLoadedColumn(this.info.inputColumn.name);
-        ColumnDescription outputColumn = new ColumnDescription(this.newColName, ContentsKind.String);
+        ColumnDescription outputColumn = new ColumnDescription(this.info.outputColumn, ContentsKind.String);
         IMutableColumn outCol = BaseColumn.create(outputColumn,
                 table.getMembershipSet().getMax(),
                 table.getMembershipSet().getSize());

--- a/platform/src/main/java/org/hillview/maps/CreateIntervalColumnMap.java
+++ b/platform/src/main/java/org/hillview/maps/CreateIntervalColumnMap.java
@@ -31,7 +31,7 @@ import java.util.List;
  * This map receives a column name of the input table, and returns a table with a new column,
  * containing the specified data converted to a new kind.
  */
-public class CreateIntervalColumnMap extends AppendColumnMap {
+public class CreateIntervalColumnMap extends AppendOrReplaceColumnMap {
     static final long serialVersionUID = 1;
 
     public static class Info implements Serializable {
@@ -44,7 +44,7 @@ public class CreateIntervalColumnMap extends AppendColumnMap {
     private final Info info;
 
     public CreateIntervalColumnMap(Info info) {
-        super(info.newColName, info.columnIndex);
+        super(info.columnIndex);
         this.info = info;
     }
 

--- a/platform/src/main/java/org/hillview/sketches/SaveAsFileSketch.java
+++ b/platform/src/main/java/org/hillview/sketches/SaveAsFileSketch.java
@@ -35,7 +35,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.HashMap;
 
 /**
  * This sketch saves a table into a set of files in the specified folder.
@@ -54,23 +53,16 @@ public class SaveAsFileSketch implements TableSketch<Empty> {
      * If true a schema file will also be created.
      */
     private final boolean createSchema;
-    /**
-     * Map that describes how columns should be renamed.
-     */
-    @Nullable
-    private final HashMap<String, String> renameMap;
 
     public SaveAsFileSketch(
             final String kind,
             final String folder,
             @Nullable final Schema schema,
-            @Nullable final HashMap<String, String> renameMap,
             boolean createSchema) {
         this.kind = kind;
         this.folder = folder;
         this.createSchema = createSchema;
         this.schema = schema;
-        this.renameMap = renameMap;
     }
 
     @Override
@@ -79,8 +71,6 @@ public class SaveAsFileSketch implements TableSketch<Empty> {
         try {
             if (this.schema != null)
                 data = data.project(this.schema);
-            if (this.renameMap != null && this.renameMap.size() != 0)
-                data = data.renameColumns(this.renameMap);
 
             // Executed for side-effect.
             data.getLoadedColumns(data.getSchema().getColumnNames());

--- a/platform/src/main/java/org/hillview/table/filters/JSFilterDescription.java
+++ b/platform/src/main/java/org/hillview/table/filters/JSFilterDescription.java
@@ -25,11 +25,8 @@ import org.hillview.table.api.ITable;
 import org.hillview.table.api.ITableFilter;
 import org.hillview.table.api.ITableFilterDescription;
 import org.hillview.table.rows.VirtualRowSnapshot;
-import org.hillview.utils.Utilities;
 
-import javax.annotation.Nullable;
 import java.io.Serializable;
-import java.util.HashMap;
 
 /**
  * A filter that uses JavaScript to filter data.
@@ -40,12 +37,10 @@ public class JSFilterDescription implements ITableFilterDescription {
     public static class Info implements Serializable {
         Schema schema;
         String jsCode;
-        @Nullable String[] renameMap;
 
-        public Info(Schema schema, String jsCode, @Nullable String[] renameMap) {
+        public Info(Schema schema, String jsCode) {
             this.schema = schema;
             this.jsCode = jsCode;
-            this.renameMap = renameMap;
         }
     }
 
@@ -61,11 +56,8 @@ public class JSFilterDescription implements ITableFilterDescription {
         private final ProxyObject vrsProxy;
 
         JSFilter(ITable table) {
-            HashMap<String, String> renameMap = Utilities.arrayToMap(JSFilterDescription.this.info.renameMap);
             try {
-                this.vrs = new VirtualRowSnapshot(
-                        table, JSFilterDescription.this.info.schema,
-                        renameMap);
+                this.vrs = new VirtualRowSnapshot(table, JSFilterDescription.this.info.schema);
                 this.vrsProxy = ProxyObject.fromMap(this.vrs);
                 Context context = Context.newBuilder().allowAllAccess(true).build();
                 // Compiles the JS function

--- a/platform/src/main/java/org/hillview/table/filters/StringColumnsFilterDescription.java
+++ b/platform/src/main/java/org/hillview/table/filters/StringColumnsFilterDescription.java
@@ -22,8 +22,6 @@ import org.hillview.table.api.*;
 import org.hillview.table.rows.VirtualRowSnapshot;
 import org.hillview.utils.Utilities;
 
-import javax.annotation.Nullable;
-
 public class StringColumnsFilterDescription implements ITableFilterDescription {
     static final long serialVersionUID = 1;
 
@@ -35,17 +33,11 @@ public class StringColumnsFilterDescription implements ITableFilterDescription {
      * The description of the filter that will be used.
      */
     private final StringFilterDescription stringFilterDescription;
-    /*
-     * Map string->string described by a string array.
-     */
-    @Nullable
-    private final String[] renameMap;
 
     public StringColumnsFilterDescription(String[] colNames, StringFilterDescription
-            stringFilterDescription, @Nullable String[] renameMap) {
+            stringFilterDescription) {
         this.colNames = colNames;
         this.stringFilterDescription = stringFilterDescription;
-        this.renameMap = renameMap;
     }
 
     @Override
@@ -63,9 +55,7 @@ public class StringColumnsFilterDescription implements ITableFilterDescription {
             this.stringFilter = StringFilterFactory.getFilter(stringFilterDescription);
             Schema schema = table.getSchema().project(
                     c -> Utilities.indexOf(StringColumnsFilterDescription.this.colNames, c) >= 0);
-            this.vrs = new VirtualRowSnapshot(
-                    table, schema,
-                    Utilities.arrayToMap(StringColumnsFilterDescription.this.renameMap));
+            this.vrs = new VirtualRowSnapshot(table, schema);
         }
 
         /**

--- a/platform/src/main/java/org/hillview/table/rows/JSVirtualRowSnapshot.java
+++ b/platform/src/main/java/org/hillview/table/rows/JSVirtualRowSnapshot.java
@@ -38,9 +38,8 @@ public class JSVirtualRowSnapshot extends VirtualRowSnapshot {
     public JSVirtualRowSnapshot(
             ITable table, Schema schema,
             @Nullable
-            HashMap<String, String> columnRenameMap,
             Context engine) {
-        super(table, schema, columnRenameMap);
+        super(table, schema);
         this.engine = engine;
     }
 

--- a/platform/src/main/java/org/hillview/table/rows/VirtualRowSnapshot.java
+++ b/platform/src/main/java/org/hillview/table/rows/VirtualRowSnapshot.java
@@ -58,28 +58,19 @@ public class VirtualRowSnapshot extends BaseRowSnapshot implements ISketchWorksp
     private final Schema schema;
     protected final HashMap<String, IColumn> columns;
 
-    public VirtualRowSnapshot(final ITable table, final Schema schema,
-            @Nullable final Map<String, String> columnRenameMap) {
+    public VirtualRowSnapshot(final ITable table, final Schema schema) {
         this.table = table;
         this.schema = schema;
         this.columns = new HashMap<String, IColumn>();
         List<IColumn> cols = table.getLoadedColumns(schema.getColumnNames());
         for (IColumn col: cols) {
             String nameToUse = col.getName();
-            if (columnRenameMap != null && columnRenameMap.containsKey(nameToUse))
-                nameToUse = columnRenameMap.get(nameToUse);
             this.columns.put(nameToUse, col);
         }
     }
 
-    public VirtualRowSnapshot(
-            final ITable table,
-            final Schema schema) {
-        this(table, schema, null);
-    }
-
     public VirtualRowSnapshot(final ITable table) {
-        this(table, table.getSchema(), null);
+        this(table, table.getSchema());
     }
 
     public boolean exists() { return this.rowIndex >= 0; }

--- a/platform/src/test/java/org/hillview/test/JavascriptTest.java
+++ b/platform/src/test/java/org/hillview/test/JavascriptTest.java
@@ -87,7 +87,7 @@ public class JavascriptTest extends BaseTest {
         LocalDataSet<ITable> lds = new LocalDataSet<ITable>(table);
         String function = "function map(row) { return row['Age'] > 18 ? 'true' : 'false'; }";
         CreateColumnJSMap.Info info = new CreateColumnJSMap.Info(
-                function, table.getSchema(), "IsAdult", ContentsKind.String, null);
+                function, table.getSchema(), "IsAdult", ContentsKind.String);
         CreateColumnJSMap map = new CreateColumnJSMap(info);
         IDataSet<ITable> mapped = lds.blockingMap(map);
         ITable outTable = ((LocalDataSet<ITable>)mapped).data;
@@ -105,7 +105,7 @@ public class JavascriptTest extends BaseTest {
         LocalDataSet<ITable> lds = new LocalDataSet<ITable>(table);
         String function = "function map(row) { return row['Age'] > 18 ? [2,3] : [3,4]; }";
         CreateColumnJSMap.Info info = new CreateColumnJSMap.Info(
-                function, table.getSchema(), "Interval", ContentsKind.Interval, null);
+                function, table.getSchema(), "Interval", ContentsKind.Interval);
         CreateColumnJSMap map = new CreateColumnJSMap(info);
         IDataSet<ITable> mapped = lds.blockingMap(map);
         ITable outTable = ((LocalDataSet<ITable>)mapped).data;
@@ -118,7 +118,7 @@ public class JavascriptTest extends BaseTest {
 
         function = "function map(row) { return row['Interval'][0] + row['Interval'][1]; }";
         info = new CreateColumnJSMap.Info(
-                function, outTable.getSchema(), "Sum", ContentsKind.Double, null);
+                function, outTable.getSchema(), "Sum", ContentsKind.Double);
         map = new CreateColumnJSMap(info);
         mapped = mapped.blockingMap(map);
         outTable = ((LocalDataSet<ITable>)mapped).data;
@@ -136,7 +136,7 @@ public class JavascriptTest extends BaseTest {
         LocalDataSet<ITable> lds = new LocalDataSet<ITable>(table);
         String function = "function map(row) { return Math.round(row['Age'] / 10) * 10; }";
         CreateColumnJSMap.Info info = new CreateColumnJSMap.Info(
-                function, table.getSchema(), "Range", ContentsKind.Double, null);
+                function, table.getSchema(), "Range", ContentsKind.Double);
         CreateColumnJSMap map = new CreateColumnJSMap(info);
         IDataSet<ITable> mapped = lds.blockingMap(map);
         ITable outTable = ((LocalDataSet<ITable>)mapped).data;
@@ -154,7 +154,7 @@ public class JavascriptTest extends BaseTest {
         LocalDataSet<ITable> lds = new LocalDataSet<ITable>(table);
         String function = "function map(row) { return Math.round(row['Age'] / 10) * 10; }";
         CreateColumnJSMap.Info info = new CreateColumnJSMap.Info(
-                function, table.getSchema(), "Range", ContentsKind.Integer, null);
+                function, table.getSchema(), "Range", ContentsKind.Integer);
         CreateColumnJSMap map = new CreateColumnJSMap(info);
         IDataSet<ITable> mapped = lds.blockingMap(map);
         ITable outTable = ((LocalDataSet<ITable>)mapped).data;
@@ -171,7 +171,7 @@ public class JavascriptTest extends BaseTest {
         ITable table = TestTables.testRepTable();
         LocalDataSet<ITable> lds = new LocalDataSet<ITable>(table);
         String function = "function filter(row) { return row['Age'] > 18; }";
-        JSFilterDescription.Info info = new JSFilterDescription.Info(table.getSchema(), function, null);
+        JSFilterDescription.Info info = new JSFilterDescription.Info(table.getSchema(), function);
         JSFilterDescription desc = new JSFilterDescription(info);
         FilterMap map = new FilterMap(desc);
         IDataSet<ITable> mapped = lds.blockingMap(map);
@@ -190,7 +190,7 @@ public class JavascriptTest extends BaseTest {
         LocalDataSet<ITable> lds = new LocalDataSet<ITable>(table);
         String function = "function map(row) { return new Date(1970 + row['Age'], 0, 1); }";
         CreateColumnJSMap.Info info = new CreateColumnJSMap.Info(
-                function, table.getSchema(), "Date", ContentsKind.LocalDate, null);
+                function, table.getSchema(), "Date", ContentsKind.LocalDate);
         CreateColumnJSMap map = new CreateColumnJSMap(info);
         IDataSet<ITable> mapped = lds.blockingMap(map);
         ITable outTable = ((LocalDataSet<ITable>)mapped).data;
@@ -217,26 +217,7 @@ public class JavascriptTest extends BaseTest {
         LocalDataSet<ITable> lds = new LocalDataSet<ITable>(table);
         String function = "function map(row) { return row['Age'] + 10; }";
         CreateColumnJSMap.Info info = new CreateColumnJSMap.Info(
-                function, table.getSchema(), "Older", ContentsKind.Integer, null);
-        CreateColumnJSMap map = new CreateColumnJSMap(info);
-        IDataSet<ITable> mapped = lds.blockingMap(map);
-        ITable outTable = ((LocalDataSet<ITable>)mapped).data;
-        Assert.assertNotNull(outTable);
-        String data = outTable.toLongString(3);
-        Assert.assertEquals("Table[3x15]\n" +
-                "Mike,20,30\n" +
-                "John,30,40\n" +
-                "Tom,10,20\n", data);
-    }
-
-    @Test
-    public void testRename() {
-        ITable table = TestTables.testRepTable();
-        LocalDataSet<ITable> lds = new LocalDataSet<ITable>(table);
-        String function = "function map(row) { return row['NewAge'] + 10; }";
-        String[] renameMap = new String[] { "Age", "NewAge" };
-        CreateColumnJSMap.Info info = new CreateColumnJSMap.Info(
-                function, table.getSchema(), "Older", ContentsKind.Integer, renameMap);
+                function, table.getSchema(), "Older", ContentsKind.Integer);
         CreateColumnJSMap map = new CreateColumnJSMap(info);
         IDataSet<ITable> mapped = lds.blockingMap(map);
         ITable outTable = ((LocalDataSet<ITable>)mapped).data;
@@ -258,7 +239,7 @@ public class JavascriptTest extends BaseTest {
         LocalDataSet<ITable> lds = new LocalDataSet<ITable>(tbl);
         String function = "function map(row) { return row['Age'] + 10; }";
         CreateColumnJSMap.Info info = new CreateColumnJSMap.Info(
-                function, table.getSchema(), "Older", ContentsKind.Integer, null);
+                function, table.getSchema(), "Older", ContentsKind.Integer);
         CreateColumnJSMap map = new CreateColumnJSMap(info);
         IDataSet<ITable> mapped = lds.blockingMap(map);
         ITable outTable = ((LocalDataSet<ITable>) mapped).data;
@@ -277,7 +258,7 @@ public class JavascriptTest extends BaseTest {
         ColumnDescription outCol = new ColumnDescription("Date", ContentsKind.LocalDate);
         String function = "function map(row) { return new Date(1970 + row['Age'], 0, 1); }";
         CreateColumnJSMap.Info info = new CreateColumnJSMap.Info(
-                function, table.getSchema(), "Date", ContentsKind.LocalDate, null);
+                function, table.getSchema(), "Date", ContentsKind.LocalDate);
         CreateColumnJSMap map = new CreateColumnJSMap(info);
         IDataSet<ITable> mapped = lds.blockingMap(map);
         // Convert the date column
@@ -289,7 +270,7 @@ public class JavascriptTest extends BaseTest {
         Schema outSchema = table.getSchema().clone();
         outSchema.append(outCol);
         CreateColumnJSMap.Info info1 = new CreateColumnJSMap.Info(
-                function, outSchema, "Later", ContentsKind.LocalDate, null);
+                function, outSchema, "Later", ContentsKind.LocalDate);
         map = new CreateColumnJSMap(info1);
         mapped = mapped.blockingMap(map);
         ITable outTable = ((LocalDataSet<ITable>)mapped).data;

--- a/platform/src/test/java/org/hillview/test/table/StringColumnFilterTest.java
+++ b/platform/src/test/java/org/hillview/test/table/StringColumnFilterTest.java
@@ -78,7 +78,7 @@ public class StringColumnFilterTest extends BaseTest {
         cols[0] = "Name";
         StringColumnsFilterDescription equalityFilter =
                 new StringColumnsFilterDescription(cols,
-                new StringFilterDescription("Ed"), null);
+                new StringFilterDescription("Ed"));
         FilterMap filterMap = new FilterMap(equalityFilter);
         ITable result = filterMap.apply(table);
         Assert.assertNotNull(result);
@@ -97,7 +97,7 @@ public class StringColumnFilterTest extends BaseTest {
 
         // Same process for Mike.
         equalityFilter = new StringColumnsFilterDescription(cols,
-                new StringFilterDescription("Mike"), null);
+                new StringFilterDescription("Mike"));
         filterMap = new FilterMap(equalityFilter);
         result = filterMap.apply(table);
         Assert.assertNotNull(result);

--- a/web/src/main/java/org/hillview/targets/TableTarget.java
+++ b/web/src/main/java/org/hillview/targets/TableTarget.java
@@ -85,6 +85,19 @@ public class TableTarget extends TableRpcTarget {
         this.runSketch(this.table, nka, request, context);
     }
 
+    @SuppressWarnings("NotNullFieldNotInitialized")
+    static class RenameArgs {
+        String fromName;
+        String toName;
+    }
+
+    @HillviewRpc
+    public void renameColumn(RpcRequest request, RpcRequestContext context) {
+        RenameArgs args = request.parseArgs(RenameArgs.class);
+        RenameColumnMap map = new RenameColumnMap(args.fromName, args.toName);
+        this.runMap(this.table, map, (d, c) -> new TableTarget(d, c, this.metadataDirectory), request, context);
+    }
+
     static class LogFragmentArgs {
         Schema schema = new Schema();
         @Nullable
@@ -180,9 +193,6 @@ public class TableTarget extends TableRpcTarget {
         String folder = "";
         @Nullable
         Schema schema;
-        // Rename map encoded as an array
-        @Nullable
-        String[] renameMap;
     }
 
     @HillviewRpc
@@ -193,8 +203,7 @@ public class TableTarget extends TableRpcTarget {
             args.folder = Paths.get(Configuration.instance.getGreenplumDumpDirectory(), args.folder).toString();
         }
         SaveAsFileSketch sk = new SaveAsFileSketch(
-                args.fileKind, args.folder, args.schema,
-                Utilities.arrayToMap(args.renameMap), true);
+                args.fileKind, args.folder, args.schema, true);
         this.runCompleteSketch(this.table, sk, request, context);
     }
 

--- a/web/src/main/webapp/dataViews/axisData.ts
+++ b/web/src/main/webapp/dataViews/axisData.ts
@@ -199,7 +199,7 @@ export class AxisData {
         this.axis = null;
     }
 
-    public getName(schema: SchemaClass): string | null {
+    public getName(): string | null {
         if (this.description == null)
             return null;
         return this.description.name;

--- a/web/src/main/webapp/dataViews/axisData.ts
+++ b/web/src/main/webapp/dataViews/axisData.ts
@@ -199,13 +199,10 @@ export class AxisData {
         this.axis = null;
     }
 
-    public getDisplayNameString(schema: SchemaClass): string | null {
+    public getName(schema: SchemaClass): string | null {
         if (this.description == null)
             return null;
-        const disp = schema.displayName(this.description.name);
-        if (disp === null)
-            return null;
-        return disp.displayName;
+        return this.description.name;
     }
 
     private static needsAdjustment(kind: ContentsKind): boolean {

--- a/web/src/main/webapp/dataViews/chartView.ts
+++ b/web/src/main/webapp/dataViews/chartView.ts
@@ -17,7 +17,6 @@
 
 import {BigTableView} from "../modules";
 import {BucketsInfo, IColumnDescription, RangeFilterArrayDescription, RecordOrder, RemoteObjectId} from "../javaBridge";
-import {DisplayName} from "../schemaClass";
 import {FullPage, PageTitle} from "../ui/fullPage";
 import {D3SvgElement, DragEventKind, Point, Resolution, ViewKind} from "../ui/ui";
 import {TextOverlay} from "../ui/textOverlay";
@@ -190,7 +189,7 @@ export abstract class ChartView<D> extends BigTableView {
         return false;
     }
 
-    protected chooseTrellis(columns: DisplayName[]): void {
+    protected chooseTrellis(columns: string[]): void {
         if (columns.length === 0) {
             this.page.reportError("No acceptable columns found");
             return;
@@ -203,7 +202,7 @@ export abstract class ChartView<D> extends BigTableView {
         dialog.show();
     }
 
-    protected abstract showTrellis(colName: DisplayName): void;
+    protected abstract showTrellis(colName: string): void;
 
     public getSourceAxisRange(sourcePageId: string, dragEvent: DragEventKind): BucketsInfo | null {
         const page = this.dataset.findPage(Number(sourcePageId));

--- a/web/src/main/webapp/dataViews/correlationHeatmapView.ts
+++ b/web/src/main/webapp/dataViews/correlationHeatmapView.ts
@@ -27,7 +27,6 @@ import {
     truncate,
     zip
 } from "../util";
-import {DisplayName} from "../schemaClass";
 import {RpcRequest} from "../rpc";
 import {CommonArgs, ReceiverCommon, ReceiverCommonArgs} from "../ui/receiver";
 import {SubMenu, TopMenu} from "../ui/menu";
@@ -259,7 +258,7 @@ export class CorrelationHeatmapView extends ChartView<Groups<Groups<number>>[]> 
         this.updateView(this.data, true);
     }
 
-    protected showTrellis(colName: DisplayName): void { /* not used */ }
+    protected showTrellis(colName: string): void { /* not used */ }
 
     protected legendSelectionCompleted(xl: number, xr: number): void {
         const [min, max] = reorder(this.colorLegend.invert(xl), this.colorLegend.invert(xr));

--- a/web/src/main/webapp/dataViews/dataRangesReceiver.ts
+++ b/web/src/main/webapp/dataViews/dataRangesReceiver.ts
@@ -394,8 +394,8 @@ export class DataRangesReceiver extends OnCompleteReceiver<BucketsInfo[]> {
                 }
                 if (this.title == null)
                     this.title = new PageTitle(
-                        "Quartiles of " + this.meta.schema.displayName(this.cds[1].name)!.toString() +
-                        " bucketed by " + this.meta.schema.displayName(this.cds[0].name)!.toString(), this.provenance!);
+                        "Quartiles of " + this.cds[1].name +
+                        " bucketed by " + this.cds[0].name, this.provenance!);
 
                 const histoArg = DataRangesReceiver.computeHistogramArgs(
                     this.cds[0], ranges[0], maxXBucketCount,
@@ -439,7 +439,7 @@ export class DataRangesReceiver extends OnCompleteReceiver<BucketsInfo[]> {
                 const axisData = new AxisData(this.cds[0], ranges[0], histoArg.bucketCount);
                 if (this.title == null)
                     this.title = new PageTitle(
-                        "Histogram of " + this.meta.schema.displayName(this.cds[0].name)!.toString(), this.provenance!);
+                        "Histogram of " + this.cds[0].name, this.provenance!);
                 const renderer = new HistogramReceiver(this.title, this.page,
                     this.originator.remoteObjectId, this.getMeta(), axisData, rr, cdfArg.samplingRate,
                     this.options.pieChart != null ? this.options.pieChart : false, this.options.reusePage); // TODO sampling rate?
@@ -463,8 +463,8 @@ export class DataRangesReceiver extends OnCompleteReceiver<BucketsInfo[]> {
                 const groupByAxis = new AxisData(this.cds[1], ranges[1]!, wArg.bucketCount);
                 if (this.title == null)
                     this.title = new PageTitle(
-                        "Histograms of " + this.meta.schema.displayName(this.cds[0].name)!.toString() +
-                        " grouped by " + this.meta.schema.displayName(this.cds[1].name)!.toString(), this.provenance!);
+                        "Histograms of " + this.cds[0].name +
+                        " grouped by " + this.cds[1].name, this.provenance!);
                 const renderer = new TrellisHistogramReceiver(this.title, this.page,
                     this.originator, this.getMeta(),
                     [xAxisData, groupByAxis], this.bucketCounts[0],
@@ -494,9 +494,9 @@ export class DataRangesReceiver extends OnCompleteReceiver<BucketsInfo[]> {
 
                 if (this.title == null)
                     this.title = new PageTitle(
-                        "Trellis quartiles of " + this.meta.schema.displayName(this.cds[1].name)!.toString() +
-                        " bucketed by " + this.meta.schema.displayName(this.cds[0].name)!.toString() +
-                        " grouped by " + this.meta.schema.displayName(this.cds[2].name)!.toString(), this.provenance!);
+                        "Trellis quartiles of " + this.cds[1].name +
+                        " bucketed by " + this.cds[0].name +
+                        " grouped by " + this.cds[2].name, this.provenance!);
 
                 const histoArg0 = DataRangesReceiver.computeHistogramArgs(
                     this.cds[0], ranges[0], maxXBucketCount,
@@ -546,9 +546,9 @@ export class DataRangesReceiver extends OnCompleteReceiver<BucketsInfo[]> {
                 if (this.title == null)
                     this.title = new PageTitle(
                         this.options.chartKind.toString().replace("Trellis", "") +
-                                 " (" + this.meta.schema.displayName(this.cds[0].name)!.displayName +
-                                 ", " + this.meta.schema.displayName(this.cds[1].name)!.displayName +
-                                 ") grouped by " + this.meta.schema.displayName(this.cds[2].name)!.displayName, this.provenance!);
+                                 " (" + this.cds[0].name +
+                                 ", " + this.cds[1].name +
+                                 ") grouped by " + this.cds[2].name, this.provenance!);
                 let renderer;
                 if (this.options.chartKind === "Trellis2DHistogram")
                     renderer = new TrellisHistogram2DReceiver(this.title, this.page,
@@ -578,8 +578,8 @@ export class DataRangesReceiver extends OnCompleteReceiver<BucketsInfo[]> {
                 const yAxis = new AxisData(this.cds[1], ranges[1]!, yArg.bucketCount);
                 if (this.title == null)
                     this.title = new PageTitle(
-                        "Heatmap (" + this.meta.schema.displayName(this.cds[0].name)!.displayName + ", " +
-                        this.meta.schema.displayName(this.cds[1].name)!.displayName + ")", this.provenance!);
+                        "Heatmap (" + this.cds[0].name + ", " +
+                        this.cds[1].name + ")", this.provenance!);
                 if (this.isPrivate()) {
                     const rr = this.originator.createHistogram2DRequest(args);
                     const renderer = new HeatmapReceiver(this.title, this.page,
@@ -634,8 +634,8 @@ export class DataRangesReceiver extends OnCompleteReceiver<BucketsInfo[]> {
                 const yData = new AxisData(this.cds[1], ranges[1]!, yarg.bucketCount);
                 if (this.title == null)
                     this.title = new PageTitle(
-                        "2DHistogram (" + this.meta.schema.displayName(this.cds[0].name)!.displayName + ", " +
-                    this.meta.schema.displayName(this.cds[1].name)!.displayName + ")", this.provenance!);
+                        "2DHistogram (" + this.cds[0].name + ", " +
+                    this.cds[1].name + ")", this.provenance!);
                 const renderer = new Histogram2DReceiver(this.title, this.page,
                     this.originator, this.getMeta(),[xAxis, yData], cdfArg.samplingRate, rr, this.options);
                 rr.chain(this.operation);

--- a/web/src/main/webapp/dataViews/geoView.ts
+++ b/web/src/main/webapp/dataViews/geoView.ts
@@ -26,7 +26,6 @@ import {ChartView} from "./chartView";
 import {FullPage, PageTitle} from "../ui/fullPage";
 import {assert, Converters, Exporter, ICancellable, PartialResult, significantDigits} from "../util";
 import {BaseReceiver, TableTargetAPI} from "../tableTarget";
-import {DisplayName} from "../schemaClass";
 import {CommonArgs, TableMeta, OnCompleteReceiverCommon, ReceiverCommonArgs} from "../ui/receiver";
 import {SubMenu, TopMenu} from "../ui/menu";
 import {IDataView} from "../ui/dataview";
@@ -156,7 +155,7 @@ export class GeoView extends ChartView<NextKList> {
     refresh(): void {
         const rr = this.createGeoRequest(this.keyColumn);
         const args: ReceiverCommonArgs = {
-            title: new PageTitle("Count of " + this.meta.schema.displayName(this.keyColumn.name)!.displayName,
+            title: new PageTitle("Count of " + this.keyColumn.name,
                 this.defaultProvenance),
             remoteObject: this,
             originalPage: this.page,
@@ -173,7 +172,7 @@ export class GeoView extends ChartView<NextKList> {
         this.updateView(this.data, true);
     }
 
-    protected showTrellis(colName: DisplayName): void {
+    protected showTrellis(colName: string): void {
         // TODO
     }
 

--- a/web/src/main/webapp/dataViews/heatmapView.ts
+++ b/web/src/main/webapp/dataViews/heatmapView.ts
@@ -27,7 +27,7 @@ import {
     RowValue,
 } from "../javaBridge";
 import {Receiver, RpcRequest} from "../rpc";
-import {DisplayName, SchemaClass} from "../schemaClass";
+import {SchemaClass} from "../schemaClass";
 import {BaseReceiver, ChartView, TableTargetAPI} from "../modules";
 import {IDataView} from "../ui/dataview";
 import {FullPage, PageTitle} from "../ui/fullPage";
@@ -168,12 +168,12 @@ export class HeatmapView extends
         const dialog = new Dialog("Details column",
             "Select the column used to display the second color map.");
         let input = dialog.addColumnSelectField("column", "Column:",
-            this.detailColumns.allDisplayNames().slice(2), null,
+            this.detailColumns.allColumnNames().slice(2), null,
             "Data in this column will be used for the second color map.");
         input.required = true;
         dialog.setAction(() => {
             const c = dialog.getColumnName("column");
-            this.detailIndex = this.detailColumns!.columnIndex(this.getSchema().fromDisplayName(c)!);
+            this.detailIndex = this.detailColumns!.columnIndex(c);
             this.resize();
         });
         dialog.show();
@@ -431,8 +431,7 @@ export class HeatmapView extends
         this.plot.draw();
 
         this.setupMouse();
-        const cols = this.getColumns().map(
-            (c) => this.getSchema().displayName(c.name)!.displayName);
+        const cols = this.getColumns().map((c) => c.name);
         cols.splice(2, 0, "count");
         assert(this.surface != null);
         this.pointDescription = new TextOverlay(
@@ -498,7 +497,7 @@ export class HeatmapView extends
     }
 
     public groupBy(): void {
-        const columns: DisplayName[] = this.getSchema().displayNamesExcluding(
+        const columns: string[] = this.getSchema().namesExcluding(
             [this.xAxisData.description.name, this.yAxisData.description.name]);
         this.chooseTrellis(columns);
     }
@@ -510,8 +509,8 @@ export class HeatmapView extends
         saveAs(fileName, lines.join("\n"));
     }
 
-    protected showTrellis(colName: DisplayName): void {
-        const groupBy = this.getSchema().findByDisplayName(colName);
+    protected showTrellis(colName: string): void {
+        const groupBy = this.getSchema().find(colName);
         if (groupBy == null)
             return;
         const cds: IColumnDescription[] = [this.xAxisData.description,

--- a/web/src/main/webapp/dataViews/heatmapView.ts
+++ b/web/src/main/webapp/dataViews/heatmapView.ts
@@ -425,7 +425,7 @@ export class HeatmapView extends
         }
         this.colorLegend.draw();
         if (this.showDetails) {
-            this.detailLegend!.setData(detailsAxisData!, false, this.detailColumns!);
+            this.detailLegend!.setData(detailsAxisData!, false);
             this.detailLegend!.draw();
         }
         this.plot.draw();

--- a/web/src/main/webapp/dataViews/heavyHittersView.ts
+++ b/web/src/main/webapp/dataViews/heavyHittersView.ts
@@ -108,7 +108,7 @@ export class HeavyHittersView extends BigTableView {
         let header: string[] = ["Rank"];
         let tips: string[] = ["Position in decreasing order of frequency."];
         this.columnsShown.forEach((c) => {
-            header.push(this.getSchema().displayName(c.name)!.displayName);
+            header.push(c.name);
             tips.push("Column name");
         });
         header = header.concat(["Count", "% (Above " + this.percent.toString() + ")", "Fraction"]);
@@ -135,7 +135,7 @@ export class HeavyHittersView extends BigTableView {
         const lines: string[] = [];
         let line = "";
         for (const c of this.columnsShown)
-            line += JSON.stringify(this.getSchema().displayName(c.name)!.displayName) + ",";
+            line += JSON.stringify(c.name) + ",";
         line += "Count,%";
         lines.push(line);
 
@@ -443,7 +443,7 @@ export class HeavyHittersReceiver extends OnCompleteReceiver<TopList> {
     public run(data: TopList): void {
         if (data.top.rows.length === 0) this.showEmptyDialog();
         else {
-            const names = this.columnsShown.map((c) => this.meta.schema.displayName(c.name)).join(", ");
+            const names = this.columnsShown.map((c) => c.name).join(", ");
             let newPage = this.page;
             if (!this.reusePage)
                 newPage = this.page.dataset!.newPage(

--- a/web/src/main/webapp/dataViews/histogram2DView.ts
+++ b/web/src/main/webapp/dataViews/histogram2DView.ts
@@ -23,7 +23,6 @@ import {
     RemoteObjectId, kindIsNumeric, Groups, RangeFilterArrayDescription,
 } from "../javaBridge";
 import {Receiver, RpcRequest} from "../rpc";
-import {DisplayName} from "../schemaClass";
 import {BaseReceiver, TableTargetAPI} from "../modules";
 import {CDFPlot} from "../ui/cdfPlot";
 import {IDataView} from "../ui/dataview";
@@ -245,11 +244,11 @@ export class Histogram2DView extends HistogramViewBase<Pair<Groups<Groups<number
 
         let pointFields;
         if (this.stacked) {
-            pointFields = [this.xAxisData.getDisplayNameString(this.getSchema())!,
-                this.yAxisData.getDisplayNameString(this.getSchema())!,
+            pointFields = [this.xAxisData.getName(this.getSchema())!,
+                this.yAxisData.getName(this.getSchema())!,
                 "bucket", "y", "count", "%", "cdf"];
         } else {
-            pointFields = ["bucket", this.yAxisData.getDisplayNameString(this.getSchema())!, "y", "count"];
+            pointFields = ["bucket", this.yAxisData.getName(this.getSchema())!, "y", "count"];
         }
 
         assert(this.surface != null);
@@ -315,13 +314,13 @@ export class Histogram2DView extends HistogramViewBase<Pair<Groups<Groups<number
     }
 
     public trellis(): void {
-        const columns: DisplayName[] = this.getSchema().displayNamesExcluding(
+        const columns: string[] = this.getSchema().namesExcluding(
             [this.xAxisData.description.name, this.yAxisData.description.name]);
         this.chooseTrellis(columns);
     }
 
-    protected showTrellis(colName: DisplayName): void {
-        const groupBy = this.getSchema().findByDisplayName(colName)!;
+    protected showTrellis(colName: string): void {
+        const groupBy = this.getSchema().find(colName)!;
         const cds: IColumnDescription[] = [
             this.xAxisData.description,
             this.yAxisData.description,

--- a/web/src/main/webapp/dataViews/histogram2DView.ts
+++ b/web/src/main/webapp/dataViews/histogram2DView.ts
@@ -219,7 +219,7 @@ export class Histogram2DView extends HistogramViewBase<Pair<Groups<Groups<number
         // Must setup legend before drawing the data to have the colormap
         const missingShown = this.histograms().perBucket.map(b => b.perMissing).reduce(add);
         if (!keepColorMap)
-            this.legendPlot.setData(this.yAxisData, missingShown > 0, this.getSchema());
+            this.legendPlot.setData(this.yAxisData, missingShown > 0);
         this.legendPlot.draw();
 
         const heatmap: Pair<Groups<Groups<number>>, Groups<Groups<number>> | null> =
@@ -244,11 +244,11 @@ export class Histogram2DView extends HistogramViewBase<Pair<Groups<Groups<number
 
         let pointFields;
         if (this.stacked) {
-            pointFields = [this.xAxisData.getName(this.getSchema())!,
-                this.yAxisData.getName(this.getSchema())!,
+            pointFields = [this.xAxisData.getName()!,
+                this.yAxisData.getName()!,
                 "bucket", "y", "count", "%", "cdf"];
         } else {
-            pointFields = ["bucket", this.yAxisData.getName(this.getSchema())!, "y", "count"];
+            pointFields = ["bucket", this.yAxisData.getName()!, "y", "count"];
         }
 
         assert(this.surface != null);

--- a/web/src/main/webapp/dataViews/histogramView.ts
+++ b/web/src/main/webapp/dataViews/histogramView.ts
@@ -24,7 +24,6 @@ import {
     RemoteObjectId, RangeFilterArrayDescription,
 } from "../javaBridge";
 import {Receiver} from "../rpc";
-import {DisplayName} from "../schemaClass";
 import {CDFPlot, NoCDFPlot} from "../ui/cdfPlot";
 import {IDataView} from "../ui/dataview";
 import {Dialog, saveAs} from "../ui/dialog";
@@ -40,7 +39,7 @@ import {
     ICancellable, makeInterval,
     PartialResult,
     percentString,
-    significantDigits, Two, assertNever, assert, Exporter, roughTimeSpan,
+    significantDigits, Two, assertNever, assert, Exporter,
 } from "../util";
 import {AxisData} from "./axisData";
 import {BucketDialog, HistogramViewBase} from "./histogramViewBase";
@@ -290,12 +289,12 @@ export class HistogramView extends HistogramViewBase<Two<Two<Groups<number>>>> /
     }
 
     public trellis(): void {
-        const columns: DisplayName[] = this.getSchema().displayNamesExcluding([this.xAxisData.description.name]);
+        const columns: string[] = this.getSchema().namesExcluding([this.xAxisData.description.name]);
         this.chooseTrellis(columns);
     }
 
-    protected showTrellis(colName: DisplayName): void {
-        const groupBy = this.getSchema().findByDisplayName(colName);
+    protected showTrellis(colName: string): void {
+        const groupBy = this.getSchema().find(colName);
         const cds: IColumnDescription[] = [this.xAxisData.description, groupBy!];
         const rr = this.createDataQuantilesRequest(cds, this.page, "TrellisHistogram");
         rr.invoke(new DataRangesReceiver(this, this.page, rr, this.meta,
@@ -317,12 +316,12 @@ export class HistogramView extends HistogramViewBase<Two<Two<Groups<number>>>> /
     }
 
     public chooseSecondColumn(): void {
-        const columns: DisplayName[] = [];
+        const columns: string[] = [];
         for (let i = 0; i < this.getSchema().length; i++) {
             const col = this.getSchema().get(i);
             if (col.name === this.xAxisData.description.name)
                 continue;
-            columns.push(this.getSchema().displayName(col.name)!);
+            columns.push(col.name);
         }
         if (columns.length === 0) {
             this.page.reportError("No other acceptable columns found");
@@ -338,13 +337,13 @@ export class HistogramView extends HistogramViewBase<Two<Two<Groups<number>>>> /
     }
 
     public chooseQuartilesColumn(): void {
-        const columns: DisplayName[] = [];
+        const columns: string[] = [];
         for (let i = 0; i < this.getSchema().length; i++) {
             const col = this.getSchema().get(i);
             if (col.name === this.xAxisData.description.name ||
                 !kindIsNumeric(col.kind))
                 continue;
-            columns.push(this.getSchema().displayName(col.name)!);
+            columns.push(col.name);
         }
         if (columns.length === 0) {
             this.page.reportError("No other acceptable columns found");
@@ -366,8 +365,8 @@ export class HistogramView extends HistogramViewBase<Two<Two<Groups<number>>>> /
         saveAs(fileName, lines.join("\n"));
     }
 
-    private showSecondColumn(colName: DisplayName): void {
-        const oc = this.getSchema().findByDisplayName(colName);
+    private showSecondColumn(colName: string): void {
+        const oc = this.getSchema().find(colName);
         const cds: IColumnDescription[] = [this.xAxisData.description, oc!];
         const rr = this.createDataQuantilesRequest(cds, this.page, "2DHistogram");
         rr.invoke(new DataRangesReceiver(this, this.page, rr, this.meta,
@@ -379,8 +378,8 @@ export class HistogramView extends HistogramViewBase<Two<Two<Groups<number>>>> /
         }));
     }
 
-    private showQuartiles(colName: DisplayName): void {
-        const oc = this.getSchema().findByDisplayName(colName);
+    private showQuartiles(colName: string): void {
+        const oc = this.getSchema().find(colName);
         const qhr = new DataRangesReceiver(this, this.page, null,
             this.meta, [this.xAxisData.bucketCount],
             [this.xAxisData.description, oc!],

--- a/web/src/main/webapp/dataViews/logFileView.ts
+++ b/web/src/main/webapp/dataViews/logFileView.ts
@@ -114,22 +114,23 @@ export class LogFileView extends TableTargetAPI implements IHtmlElement, OnNextK
         const row = document.createElement("tr");
         row.className = "logHeader";
         tbl.appendChild(row);
-        for (const col of this.schema.columnNames) {
+        for (const col of this.schema.schema) {
+            const colName = col.name;
             const cell = row.insertCell();
-            cell.textContent = col;
-            cell.onclick = () => this.rotateColor(col, cell);
+            cell.textContent = colName;
+            cell.onclick = () => this.rotateColor(colName, cell);
             const check = document.createElement("input");
             check.type = "checkbox";
             let checked = true;
-            if (col === GenericLogs.filenameColumn ||
-                col === GenericLogs.directoryColumn)
+            if (colName === GenericLogs.filenameColumn ||
+                colName === GenericLogs.directoryColumn)
                 checked = false;
             check.checked = checked;
-            check.onclick = (e) => { this.check(col); e.stopPropagation(); };
+            check.onclick = (e) => { this.check(colName); e.stopPropagation(); };
             cell.appendChild(check);
             if (checked)
-                this.visibleColumns.add(col);
-            this.color.set(col, "black");
+                this.visibleColumns.add(colName);
+            this.color.set(colName, "black");
         }
     }
 

--- a/web/src/main/webapp/dataViews/quartilesHistogramView.ts
+++ b/web/src/main/webapp/dataViews/quartilesHistogramView.ts
@@ -150,7 +150,7 @@ export class QuartilesHistogramView extends HistogramViewBase<Groups<SampleSet>>
         assert(this.surface != null);
         this.pointDescription = new TextOverlay(this.surface.getChart(),
             this.surface.getActualChartSize(),
-            [this.xAxisData.getName(this.getSchema())!, "bucket",
+            [this.xAxisData.getName()!, "bucket",
                 "max", "q3", "median", "q1", "min", "count", "missing"], 40);
         this.pointDescription.show(false);
         this.standardSummary();

--- a/web/src/main/webapp/dataViews/quartilesHistogramView.ts
+++ b/web/src/main/webapp/dataViews/quartilesHistogramView.ts
@@ -42,7 +42,6 @@ import {
 import {AxisData, AxisKind} from "./axisData";
 import {BucketDialog, HistogramViewBase} from "./histogramViewBase";
 import {DataRangesReceiver, NewTargetReceiver} from "./dataRangesReceiver";
-import {DisplayName} from "../schemaClass";
 import {Quartiles2DPlot} from "../ui/quartiles2DPlot";
 import {saveAs} from "../ui/dialog";
 import {TableMeta} from "../ui/receiver";
@@ -97,13 +96,13 @@ export class QuartilesHistogramView extends HistogramViewBase<Groups<SampleSet>>
     }
 
     public trellis(): void {
-        const columns: DisplayName[] = this.getSchema().displayNamesExcluding(
+        const columns: string[] = this.getSchema().namesExcluding(
             [this.xAxisData.description.name, this.qCol.name]);
         this.chooseTrellis(columns);
     }
 
-    protected showTrellis(colName: DisplayName): void {
-        const groupBy = this.getSchema().findByDisplayName(colName)!;
+    protected showTrellis(colName: string): void {
+        const groupBy = this.getSchema().find(colName)!;
         const cds: IColumnDescription[] = [
             this.xAxisData.description,
             this.qCol,
@@ -151,7 +150,7 @@ export class QuartilesHistogramView extends HistogramViewBase<Groups<SampleSet>>
         assert(this.surface != null);
         this.pointDescription = new TextOverlay(this.surface.getChart(),
             this.surface.getActualChartSize(),
-            [this.xAxisData.getDisplayNameString(this.getSchema())!, "bucket",
+            [this.xAxisData.getName(this.getSchema())!, "bucket",
                 "max", "q3", "median", "q1", "min", "count", "missing"], 40);
         this.pointDescription.show(false);
         this.standardSummary();

--- a/web/src/main/webapp/dataViews/spectrumView.ts
+++ b/web/src/main/webapp/dataViews/spectrumView.ts
@@ -24,7 +24,6 @@ import {
     RemoteObjectId, Groups
 } from "../javaBridge";
 import {OnCompleteReceiver} from "../rpc";
-import {DisplayName} from "../schemaClass";
 import {BaseReceiver, TableTargetAPI} from "../modules";
 import {IDataView} from "../ui/dataview";
 import {Dialog, FieldKind} from "../ui/dialog";
@@ -137,7 +136,7 @@ export class SpectrumView extends ChartView<Groups<number>> {
     }
 
     // noinspection JSUnusedLocalSymbols
-    protected showTrellis(colName: DisplayName): void { /* not used */ }
+    protected showTrellis(colName: string): void { /* not used */ }
 
     protected createNewSurfaces(): void {
         if (this.surface != null)

--- a/web/src/main/webapp/dataViews/trellisChartView.ts
+++ b/web/src/main/webapp/dataViews/trellisChartView.ts
@@ -17,7 +17,6 @@
 
 import {AxisData, AxisDescription} from "./axisData";
 import {RangeFilterArrayDescription, RemoteObjectId} from "../javaBridge";
-import {DisplayName} from "../schemaClass";
 import {FullPage} from "../ui/fullPage";
 import {Point, Resolution, ViewKind} from "../ui/ui";
 import {ChartView} from "../modules";
@@ -81,7 +80,7 @@ export abstract class TrellisChartView<D> extends ChartView<D> {
     }
 
     // noinspection JSUnusedLocalSymbols
-    protected showTrellis(colName: DisplayName): void {}
+    protected showTrellis(colName: string): void {}
 
     /**
      * Create the surfaces to display the data on.

--- a/web/src/main/webapp/dataViews/trellisHeatmapView.ts
+++ b/web/src/main/webapp/dataViews/trellisHeatmapView.ts
@@ -362,18 +362,18 @@ export class TrellisHeatmapView extends TrellisChartView<Groups<Groups<Groups<nu
         assert(this.surface != null);
         this.pointDescription = new TextOverlay(this.surface.getCanvas(),
             this.surface.getActualChartSize(),
-            [this.xAxisData.getDisplayNameString(this.getSchema())!,
-                this.yAxisData.getDisplayNameString(this.getSchema())!,
-                this.groupByAxisData.getDisplayNameString(this.getSchema())!,
+            [this.xAxisData.getName(this.getSchema())!,
+                this.yAxisData.getName(this.getSchema())!,
+                this.groupByAxisData.getName(this.getSchema())!,
                 "count"], 40);
 
         // Axis labels
         const canvas = this.surface.getCanvas();
         canvas.append("text")
-            .text(this.getSchema().displayName(this.yAxisData.description.name))
+            .text(this.yAxisData.description.name)
             .attr("dominant-baseline", "text-before-edge");
         canvas.append("text")
-            .text(this.getSchema().displayName(this.xAxisData.description.name))
+            .text(this.xAxisData.description.name)
             .attr("transform", `translate(${this.surface.getChartWidth() / 2},
                       ${this.surface.getChartHeight() + this.surface.topMargin +
             this.surface.bottomMargin / 2})`)

--- a/web/src/main/webapp/dataViews/trellisHeatmapView.ts
+++ b/web/src/main/webapp/dataViews/trellisHeatmapView.ts
@@ -362,9 +362,9 @@ export class TrellisHeatmapView extends TrellisChartView<Groups<Groups<Groups<nu
         assert(this.surface != null);
         this.pointDescription = new TextOverlay(this.surface.getCanvas(),
             this.surface.getActualChartSize(),
-            [this.xAxisData.getName(this.getSchema())!,
-                this.yAxisData.getName(this.getSchema())!,
-                this.groupByAxisData.getName(this.getSchema())!,
+            [this.xAxisData.getName()!,
+                this.yAxisData.getName()!,
+                this.groupByAxisData.getName()!,
                 "count"], 40);
 
         // Axis labels

--- a/web/src/main/webapp/dataViews/trellisHistogram2DView.ts
+++ b/web/src/main/webapp/dataViews/trellisHistogram2DView.ts
@@ -433,9 +433,9 @@ export class TrellisHistogram2DView extends TrellisChartView<Groups<Groups<Group
         assert(this.surface != null);
         this.pointDescription = new TextOverlay(this.surface.getCanvas(),
             this.surface.getActualChartSize(),
-            [this.xAxisData.getDisplayNameString(this.getSchema())!,
-                this.legendAxisData.getDisplayNameString(this.getSchema())!,
-                this.groupByAxisData.getDisplayNameString(this.getSchema())!,
+            [this.xAxisData.getName(this.getSchema())!,
+                this.legendAxisData.getName(this.getSchema())!,
+                this.groupByAxisData.getName(this.getSchema())!,
                 "y",
                 "percent",
                 "count" /* TODO:, "cdf" */], 40);

--- a/web/src/main/webapp/dataViews/trellisHistogram2DView.ts
+++ b/web/src/main/webapp/dataViews/trellisHistogram2DView.ts
@@ -405,7 +405,7 @@ export class TrellisHistogram2DView extends TrellisChartView<Groups<Groups<Group
             this.maxYAxis = max;
         }
 
-        this.legendPlot.setData(this.legendAxisData, this.legendAxisData.dataRange.missingCount > 0, this.getSchema());
+        this.legendPlot.setData(this.legendAxisData, this.legendAxisData.dataRange.missingCount > 0);
         this.legendPlot.draw();
 
         for (let i = 0; i < data.perBucket.length; i++) {
@@ -433,9 +433,9 @@ export class TrellisHistogram2DView extends TrellisChartView<Groups<Groups<Group
         assert(this.surface != null);
         this.pointDescription = new TextOverlay(this.surface.getCanvas(),
             this.surface.getActualChartSize(),
-            [this.xAxisData.getName(this.getSchema())!,
-                this.legendAxisData.getName(this.getSchema())!,
-                this.groupByAxisData.getName(this.getSchema())!,
+            [this.xAxisData.getName()!,
+                this.legendAxisData.getName()!,
+                this.groupByAxisData.getName()!,
                 "y",
                 "percent",
                 "count" /* TODO:, "cdf" */], 40);

--- a/web/src/main/webapp/dataViews/trellisHistogramQuartilesView.ts
+++ b/web/src/main/webapp/dataViews/trellisHistogramQuartilesView.ts
@@ -253,7 +253,7 @@ export class TrellisHistogramQuartilesView extends TrellisChartView<Groups<Group
 
     protected export(): void {
         let lines: string[] = [];
-        const axisName = this.getSchema().displayName(this.groupByAxisData.description.name);
+        const axisName = this.groupByAxisData.description.name;
         let bucketNo = 0;
         for (const g of allBuckets(this.data)) {
             const desc = this.groupByAxisData.bucketDescription(bucketNo++, 0);
@@ -358,8 +358,8 @@ export class TrellisHistogramQuartilesView extends TrellisChartView<Groups<Group
         this.setupMouse();
         this.pointDescription = new TextOverlay(this.surface!.getCanvas(),
             this.surface!.getActualChartSize(),
-            [this.xAxisData.getDisplayNameString(this.getSchema())!,
-                this.groupByAxisData.getDisplayNameString(this.getSchema())!,
+            [this.xAxisData.getName(this.getSchema())!,
+                this.groupByAxisData.getName(this.getSchema())!,
                 "bucket", "max", "q3", "median", "q1", "min", "count", "missing"], 40);
         this.pointDescription.show(false);
         this.standardSummary();

--- a/web/src/main/webapp/dataViews/trellisHistogramQuartilesView.ts
+++ b/web/src/main/webapp/dataViews/trellisHistogramQuartilesView.ts
@@ -358,8 +358,8 @@ export class TrellisHistogramQuartilesView extends TrellisChartView<Groups<Group
         this.setupMouse();
         this.pointDescription = new TextOverlay(this.surface!.getCanvas(),
             this.surface!.getActualChartSize(),
-            [this.xAxisData.getName(this.getSchema())!,
-                this.groupByAxisData.getName(this.getSchema())!,
+            [this.xAxisData.getName()!,
+                this.groupByAxisData.getName()!,
                 "bucket", "max", "q3", "median", "q1", "min", "count", "missing"], 40);
         this.pointDescription.show(false);
         this.standardSummary();

--- a/web/src/main/webapp/dataViews/trellisHistogramView.ts
+++ b/web/src/main/webapp/dataViews/trellisHistogramView.ts
@@ -352,8 +352,8 @@ export class TrellisHistogramView extends TrellisChartView<Two<Groups<Groups<num
         this.setupMouse();
         this.pointDescription = new TextOverlay(this.surface.getCanvas(),
             this.surface.getActualChartSize(),
-            [this.xAxisData.getName(this.getSchema())!,
-                this.groupByAxisData.getName(this.getSchema())!,
+            [this.xAxisData.getName()!,
+                this.groupByAxisData.getName()!,
                 "count", "cdf"], 40);
         this.cdfDot = this.surface.getChart()
             .append("circle")

--- a/web/src/main/webapp/dataViews/trellisHistogramView.ts
+++ b/web/src/main/webapp/dataViews/trellisHistogramView.ts
@@ -23,7 +23,6 @@ import {
 } from "../javaBridge";
 import {FullPage, PageTitle} from "../ui/fullPage";
 import {BaseReceiver, TableTargetAPI} from "../modules";
-import {DisplayName} from "../schemaClass";
 import {
     add, assert, assertNever,
     Converters, Exporter,
@@ -169,13 +168,13 @@ export class TrellisHistogramView extends TrellisChartView<Two<Groups<Groups<num
     }
 
     public chooseSecondColumn(): void {
-        const columns: DisplayName[] = [];
+        const columns: string[] = [];
         for (let i = 0; i < this.getSchema().length; i++) {
             const col = this.getSchema().get(i);
             if (col.name === this.xAxisData.description!.name ||
                 col.name === this.groupByAxisData.description!.name)
                 continue;
-            columns.push(this.getSchema().displayName(col.name)!);
+            columns.push(col.name);
         }
         if (columns.length === 0) {
             this.page.reportError("No other acceptable columns found");
@@ -191,8 +190,8 @@ export class TrellisHistogramView extends TrellisChartView<Two<Groups<Groups<num
         dialog.show();
     }
 
-    protected showSecondColumn(colName: DisplayName): void {
-        const col = this.getSchema().findByDisplayName(colName)!;
+    protected showSecondColumn(colName: string): void {
+        const col = this.getSchema().find(colName)!;
         const cds = [this.xAxisData.description, col, this.groupByAxisData.description];
         const rr = this.createDataQuantilesRequest(cds, this.page, "Trellis2DHistogram");
         rr.invoke(new DataRangesReceiver(this, this.page, rr, this.meta,
@@ -353,8 +352,8 @@ export class TrellisHistogramView extends TrellisChartView<Two<Groups<Groups<num
         this.setupMouse();
         this.pointDescription = new TextOverlay(this.surface.getCanvas(),
             this.surface.getActualChartSize(),
-            [this.xAxisData.getDisplayNameString(this.getSchema())!,
-                this.groupByAxisData.getDisplayNameString(this.getSchema())!,
+            [this.xAxisData.getName(this.getSchema())!,
+                this.groupByAxisData.getName(this.getSchema())!,
                 "count", "cdf"], 40);
         this.cdfDot = this.surface.getChart()
             .append("circle")

--- a/web/src/main/webapp/datasetView.ts
+++ b/web/src/main/webapp/datasetView.ts
@@ -28,9 +28,8 @@ import {
     CombineOperators, HistogramRequestInfo,
     IColumnDescription, JsonString, PrivacySchema,
     RecordOrder,
-    RemoteObjectId, RowValue,
+    RemoteObjectId, RowValue, Schema,
 } from "./javaBridge";
-import {SchemaClassSerialization} from "./schemaClass";
 import {BigTableView, TableTargetAPI} from "./tableTarget";
 import {HillviewToplevel} from "./toplevel";
 import {IDataView} from "./ui/dataview";
@@ -58,7 +57,7 @@ export interface IViewSerialization {
     provenance: string;
     remoteObjectId: RemoteObjectId;
     rowCount: number;
-    schema: SchemaClassSerialization;
+    schema: Schema;
     geoMetadata: ColumnGeoRepresentation[];
 }
 
@@ -94,7 +93,7 @@ export interface BaseHeatmapSerialization extends IViewSerialization {
 }
 
 export interface HeatmapSerialization extends BaseHeatmapSerialization {
-    detailedColumns: SchemaClassSerialization | null;
+    detailedColumns: Schema | null;
 }
 
 export interface MapSerialization extends IViewSerialization {

--- a/web/src/main/webapp/javaBridge.ts
+++ b/web/src/main/webapp/javaBridge.ts
@@ -87,7 +87,6 @@ export interface SaveAsArgs {
     fileKind: DataKinds;
     folder: string;
     schema: Schema | null;
-    renameMap: string[] | null;
 }
 
 // Describes the configuration of the UI for a specific installation of Hillview
@@ -207,7 +206,6 @@ export interface CreateColumnJSMapInfo {
     schema: Schema;
     outputColumn: string;
     outputKind: ContentsKind;
-    renameMap: string[];
 }
 
 export interface ExtractValueFromKeyMapInfo {
@@ -323,6 +321,11 @@ export interface BasicColStats {
     maxString?: string;
 }
 
+export interface RenameArgs {
+    fromName: string;
+    toName: string;
+}
+
 export interface RangeFilterDescription {
     min: number | null;
     max: number | null;
@@ -340,7 +343,6 @@ export interface RangeFilterArrayDescription {
 export interface JSFilterInfo {
     jsCode: string;
     schema: Schema;
-    renameMap: string[];
 }
 
 export interface RowFilterDescription {

--- a/web/src/main/webapp/schemaClass.ts
+++ b/web/src/main/webapp/schemaClass.ts
@@ -16,171 +16,58 @@
  */
 
 import {IColumnDescription, Schema} from "./javaBridge";
-import {cloneArray, mapToArray, Serializable} from "./util";
-
-export interface SchemaClassSerialization {
-    schema: Schema;
-    displayNameMap: string[];
-}
-
-/**
- * A wrapper for a name of a column that is being displayed.
- * We put this in a class to make it easier for the compiler to catch misuses of column names.
- */
-export class DisplayName {
-    public constructor(public displayName: string) {
-        console.assert(displayName !== null);
-    }
-    public toString(): string {
-        return this.displayName;
-    }
-    public equals(other: DisplayName): boolean {
-        return this.displayName === other.displayName;
-    }
-}
+import {assert, cloneArray, Serializable} from "./util";
 
 /**
  * A SchemaClass is a class containing a Schema and some indexes and methods
  * for fast access.
  */
 export class SchemaClass implements Serializable<SchemaClass> {
-    public columnNames: string[];
     private columnMap: Map<string, number>;
-    /**
-     * Each column can have a different display name.
-     */
-    private displayNameMap: Map<string, DisplayName>;
-    /**
-     * Maps the display name (the string part) to the real name.
-     * Reverse of the displayNameMap.
-     */
-    private reverseDisplayNameMap: Map<string, string>;
 
-    private initialize(): void {
-        this.columnNames = [];
+    // Return 'true' if it succeeds.
+    private initialize(): boolean {
         this.columnMap = new Map<string, number>();
         for (let i = 0; i < this.schema.length; i++) {
             const colName = this.schema[i].name;
-            this.columnNames.push(colName);
+            if (this.columnMap.has(colName))
+                return false;
             this.columnMap.set(colName, i);
         }
-        this.displayNameMap = new Map<string, DisplayName>();
-        this.reverseDisplayNameMap = new Map<string, string>();
+        return true;
     }
 
     constructor(public schema: Schema) {
-        this.initialize();
+        assert(this.initialize());
     }
 
-    public copyDisplayNames(schema: SchemaClass): void {
-        this.displayNameMap = new Map<string, DisplayName>();
-        for (const col of this.columnNames) {
-            if (schema.displayNameMap.has(col)) {
-                const displayName = schema.displayNameMap.get(col);
-                this.displayNameMap.set(col, displayName);
-                this.reverseDisplayNameMap.set(displayName.displayName, col);
-            }
-        }
+    public serialize(): Schema {
+        return this.schema;
     }
 
-    /**
-     * Returns an array encoding the column renaming: even elements are original names,
-     * odd elements are new names.
-     */
-    public getRenameVector(): string[] {
-        const result: string[] = [];
-        this.displayNameMap.forEach((v, k) => { result.push(k); result.push(v.displayName); });
-        return result;
-    }
-
-    public serialize(): SchemaClassSerialization {
-        return {
-            schema: this.schema,
-            displayNameMap: mapToArray(this.displayNameMap),
-        };
-    }
-
-    public deserialize(data: SchemaClassSerialization): SchemaClass | null {
-        if (data == null)
-            return null;
-        this.schema = data.schema;
-        const dn: string[] = data.displayNameMap;
-
-        if (this.schema == null || dn == null)
-            return null;
-        this.initialize();
-        if (dn.length % 2 !== 0)
-            return null;
-        for (let i = 0; i < dn.length; i += 2) {
-            const success = this.changeDisplayName(new DisplayName(dn[i]), dn[i + 1]);
-            if (!success)
-                return null;
-        }
-        return this;
-    }
-
-    public allDisplayNames(): DisplayName[] {
-        return this.columnNames.map((c) => this.displayName(c)!);
-    }
-
-    /**
-     * All display names except the ones for the specified columns.
-     * @param names  Names to exclude.
-     */
-    public displayNamesExcluding(names: string[]): DisplayName[] {
-        return this.columnNames
-            .filter((n) => names.indexOf(n) < 0)
-            .map((c) => this.displayName(c)!);
-    }
-
-    /**
-     * Get the display name of the specified column.
-     */
-    public displayName(name: string | null): DisplayName | null {
-        if (name == null)
-            return null;
-        if (this.displayNameMap.has(name))
-            return this.displayNameMap.get(name);
-        return new DisplayName(name);
-    }
-
-    /**
-     * Given a display name get the real column name.
-     */
-    public fromDisplayName(displayName: DisplayName | null): string | null {
-        if (displayName == null)
-            return null;
-        if (this.reverseDisplayNameMap.has(displayName.displayName))
-            return this.reverseDisplayNameMap.get(displayName.displayName);
-        console.assert(this.columnMap.has(displayName.displayName));
-        return displayName.displayName;
-    }
-
-    /**
-     * Change the display name of a column.  Mutates the current schema!
-     * Display names have to be unique within a schema.
-     * @returns {boolean}  True if the new name is acceptable.
-     */
-    public changeDisplayName(name: DisplayName, to: string): boolean {
-        if (this.reverseDisplayNameMap.has(to))
-            return false;
-        if (this.columnMap.has(to) && !this.displayNameMap.has(to))
-            return false;
-        if (this.displayNameMap.has(name.displayName))
-            this.reverseDisplayNameMap.delete(this.displayNameMap.get(name.displayName).displayName);
-        this.displayNameMap.set(name.displayName, new DisplayName(to));
-        this.reverseDisplayNameMap.set(to, name.displayName);
-        return true;
+    public deserialize(data: Schema): SchemaClass | null {
+        return new SchemaClass(data);
     }
 
     public uniqueColumnName(prefix: string): string {
         let name = prefix;
         let i = 0;
-        while (this.columnMap.has(name) || this.reverseDisplayNameMap.has(name)) {
+        while (this.columnMap.has(name)) {
             name = prefix + `_${i}`;
             i++;
         }
         return name;
+    }
+
+    /**
+     * Rename the specified column.  Return null on failure.
+     */
+    public renameColumn(from: string, to: string): SchemaClass | null {
+        if (this.find(to) != null) {
+            return null;
+        }
+        const s = this.schema.map(c => c.name == from ? { name: to, kind: c.kind } : c);
+        return new SchemaClass(s);
     }
 
     public columnIndex(colName: string): number {
@@ -198,16 +85,9 @@ export class SchemaClass implements Serializable<SchemaClass> {
         return null;
     }
 
-    public findByDisplayName(displayName: DisplayName | null): IColumnDescription | null {
-        const original = this.fromDisplayName(displayName);
-        return this.find(original);
-    }
-
     public filter(predicate: (c: IColumnDescription) => boolean): SchemaClass {
         const cols = this.schema.filter(predicate);
-        const result = new SchemaClass(cols);
-        result.copyDisplayNames(this);
-        return result;
+        return new SchemaClass(cols);
     }
 
     public insert(cd: IColumnDescription, index: number): SchemaClass {
@@ -215,21 +95,15 @@ export class SchemaClass implements Serializable<SchemaClass> {
             return this.append(cd);
         const copy = cloneArray(this.schema);
         copy.splice(index, 0, cd);
-        const result = new SchemaClass(copy);
-        result.copyDisplayNames(this);
-        return result;
+        return new SchemaClass(copy);
     }
 
     public append(cd: IColumnDescription): SchemaClass {
-        const result = new SchemaClass(this.schema.concat(cd));
-        result.copyDisplayNames(this);
-        return result;
+        return new SchemaClass(this.schema.concat(cd));
     }
 
     public concat(cds: IColumnDescription[]): SchemaClass {
-        const result = new SchemaClass(this.schema.concat(cds));
-        result.copyDisplayNames(this);
-        return result;
+        return new SchemaClass(this.schema.concat(cds));
     }
 
     public get length(): number {
@@ -241,9 +115,16 @@ export class SchemaClass implements Serializable<SchemaClass> {
     }
 
     public clone(): SchemaClass {
-        const result = new SchemaClass(this.schema);
-        result.copyDisplayNames(this);
-        return result;
+        return this.concat([]);
+    }
+
+    public allColumnNames(): string[] {
+        return this.schema.map(d => d.name);
+    }
+
+    public namesExcluding(names: string[]): string[] {
+        return this.schema.map(c => c.name)
+            .filter((n) => names.indexOf(n) < 0);
     }
 
     public getDescriptions(columns: string[]): (IColumnDescription | null)[] {

--- a/web/src/main/webapp/tableTarget.ts
+++ b/web/src/main/webapp/tableTarget.ts
@@ -56,7 +56,7 @@ import {
     CreateIntervalColumnMapInfo,
     HeatmapRequestInfo,
     RowValue,
-    MapAndColumnRepresentation, FilterListDescription, TableMetadata
+    MapAndColumnRepresentation, FilterListDescription, TableMetadata, RenameArgs
 } from "./javaBridge";
 import {OnCompleteReceiver, RemoteObject, RpcRequest} from "./rpc";
 import {FullPage, PageTitle} from "./ui/fullPage";
@@ -360,12 +360,18 @@ export class TableTargetAPI extends RemoteObject {
 
     public createCorrelationMatrixRequest(columnNames: string[], totalRows: number, toSample: boolean):
 RpcRequest<RemoteObjectId> {
-        return this.createStreamingRpcRequest<RemoteObjectId>("correlationMatrix", {
+        const args = {
             columnNames: columnNames,
             totalRows: totalRows,
             seed: Seed.instance.get(),
             toSample: toSample
-        });
+        };
+        return this.createStreamingRpcRequest<RemoteObjectId>("correlationMatrix", args);
+    }
+
+    public createRenameRequest(from: string, to: string): RpcRequest<RemoteObjectId> {
+        const a: RenameArgs = { fromName: from, toName: to };
+        return this.createStreamingRpcRequest<RemoteObjectId>("renameColumn", a);
     }
 
     public createProjectRequest(schema: Schema): RpcRequest<RemoteObjectId> {

--- a/web/src/main/webapp/test.ts
+++ b/web/src/main/webapp/test.ts
@@ -197,11 +197,10 @@ export class Test {
                 (formField as HTMLInputElement).value = "Date";
                 const confirm = findElement(".dialog .confirm");
                 confirm.click();
-                this.next(); // synchronous -- fall into next test
             }
         }, {
             description: "drop column Cancelled",
-            cond: () => true,
+            cond: () => Test.existsElement("#hillviewPage1 .idle"),
             cont: () => {
                 // Drop column cancelled
                 const cancCol = findElement("#hillviewPage1 thead td[data-colname=Cancelled] .truncated");

--- a/web/src/main/webapp/ui/dialog.ts
+++ b/web/src/main/webapp/ui/dialog.ts
@@ -20,7 +20,6 @@ import {event as d3event, select as d3select} from "d3-selection";
 import {cloneArray, makeId, makeSpan, makeInputBox, px} from "../util";
 import {EditBox} from "./editBox";
 import {IHtmlElement, Point} from "./ui";
-import {DisplayName} from "../schemaClass";
 import * as FileSaver from "file-saver";
 
 export enum FieldKind {
@@ -569,15 +568,15 @@ export class Dialog extends DialogBase {
      * @return       A reference to the select html input field.
      */
     public addColumnSelectField(fieldName: string, labelText: string,
-                                options: DisplayName[], value: DisplayName | null,
+                                options: string[], value: string | null,
                                 toolTip: string): HTMLInputElement | HTMLSelectElement {
         let v = null;
         if (value !== null)
-            v = value.displayName;
+            v = value;
         else if (options.length > 0)
-            v = options[0].displayName;
+            v = options[0];
         return this.addSelectInternal(
-            fieldName, labelText, options.map((c) => c.displayName),
+            fieldName, labelText, options,
             v, toolTip, FieldKind.ColumnName);
     }
 
@@ -621,10 +620,10 @@ export class Dialog extends DialogBase {
      * Get the value associated with a field that represents a column name.
      * @param field  Field name.
      */
-    public getColumnName(field: string): DisplayName {
+    public getColumnName(field: string): string {
         const f = this.fields.get(field);
         console.assert(f.type === FieldKind.ColumnName);
-        return new DisplayName(f.html.value);
+        return f.html.value;
     }
 
     /**
@@ -665,10 +664,10 @@ export class Dialog extends DialogBase {
      * @param {string} field  Field whose value is set.
      * @param value  Value that is being set.
      */
-    public setColumnValue(field: string, value: DisplayName): void {
+    public setColumnValue(field: string, value: string): void {
         const f = this.fields.get(field);
         console.assert(f.type === FieldKind.ColumnName);
-        f.html.value = value.displayName;
+        f.html.value = value;
     }
 
     /**

--- a/web/src/main/webapp/ui/heatmapPlot.ts
+++ b/web/src/main/webapp/ui/heatmapPlot.ts
@@ -77,10 +77,10 @@ export class HeatmapPlot
         const canvas = this.plottingSurface.getCanvas();
         if (this.showAxes) {
             canvas.append("text")
-                .text(this.yAxisData.getDisplayNameString(this.schema))
+                .text(this.yAxisData.getName(this.schema))
                 .attr("dominant-baseline", "text-before-edge");
             canvas.append("text")
-                .text(this.xAxisData.getDisplayNameString(this.schema))
+                .text(this.xAxisData.getName(this.schema))
                 .attr("x", this.getChartWidth() / 2)
                 .attr("y", this.getChartHeight() + this.plottingSurface.topMargin +
                         this.plottingSurface.bottomMargin / 2)

--- a/web/src/main/webapp/ui/heatmapPlot.ts
+++ b/web/src/main/webapp/ui/heatmapPlot.ts
@@ -77,10 +77,10 @@ export class HeatmapPlot
         const canvas = this.plottingSurface.getCanvas();
         if (this.showAxes) {
             canvas.append("text")
-                .text(this.yAxisData.getName(this.schema))
+                .text(this.yAxisData.getName())
                 .attr("dominant-baseline", "text-before-edge");
             canvas.append("text")
-                .text(this.xAxisData.getName(this.schema))
+                .text(this.xAxisData.getName())
                 .attr("x", this.getChartWidth() / 2)
                 .attr("y", this.getChartHeight() + this.plottingSurface.topMargin +
                         this.plottingSurface.bottomMargin / 2)

--- a/web/src/main/webapp/ui/histogram2DBase.ts
+++ b/web/src/main/webapp/ui/histogram2DBase.ts
@@ -64,7 +64,7 @@ export abstract class Histogram2DBase extends Plot<Pair<Groups<Groups<number>>, 
         this.xAxisData.setResolution(this.getChartWidth(), AxisKind.Bottom, PlottingSurface.bottomMargin);
         // Axis legends
         this.plottingSurface.getCanvas().append("text")
-            .text(this.xAxisData.getDisplayNameString(this.schema))
+            .text(this.xAxisData.getName(this.schema))
             .attr("transform", `translate(${this.getChartWidth() / 2},
             ${this.getChartHeight() + this.plottingSurface.topMargin + this.plottingSurface.bottomMargin / 2})`)
             .attr("text-anchor", "middle")

--- a/web/src/main/webapp/ui/histogram2DBase.ts
+++ b/web/src/main/webapp/ui/histogram2DBase.ts
@@ -64,7 +64,7 @@ export abstract class Histogram2DBase extends Plot<Pair<Groups<Groups<number>>, 
         this.xAxisData.setResolution(this.getChartWidth(), AxisKind.Bottom, PlottingSurface.bottomMargin);
         // Axis legends
         this.plottingSurface.getCanvas().append("text")
-            .text(this.xAxisData.getName(this.schema))
+            .text(this.xAxisData.getName())
             .attr("transform", `translate(${this.getChartWidth() / 2},
             ${this.getChartHeight() + this.plottingSurface.topMargin + this.plottingSurface.bottomMargin / 2})`)
             .attr("text-anchor", "middle")

--- a/web/src/main/webapp/ui/histogramLegendPlot.ts
+++ b/web/src/main/webapp/ui/histogramLegendPlot.ts
@@ -50,7 +50,7 @@ export class HistogramLegendPlot extends LegendPlot<void> {
     public draw(): void {
         this.plottingSurface.getCanvas()
             .append("text")
-            .text(this.axisData.getDisplayNameString(this.schema))
+            .text(this.axisData.getName(this.schema))
             .attr("transform", `translate(${this.getChartWidth() / 2}, 0)`)
             .attr("text-anchor", "middle")
             .attr("dominant-baseline", "text-before-edge");

--- a/web/src/main/webapp/ui/histogramLegendPlot.ts
+++ b/web/src/main/webapp/ui/histogramLegendPlot.ts
@@ -18,7 +18,6 @@
 import {AxisData, AxisKind} from "../dataViews/axisData";
 import {Plot} from "./plot";
 import {Resolution} from "./ui";
-import {SchemaClass} from "../schemaClass";
 import {LegendPlot} from "./legendPlot";
 import {HtmlPlottingSurface} from "./plottingSurface";
 import {assertNever, ColorMap, desaturateOutsideRange} from "../util";
@@ -37,7 +36,6 @@ export class HistogramLegendPlot extends LegendPlot<void> {
     protected readonly missingGap = 30;
     protected readonly missingWidth = 20;
     protected colorWidth: number;
-    protected schema: SchemaClass;
     public    colorMap: ColorMap;
     protected originalMap: ColorMap;
 
@@ -50,7 +48,7 @@ export class HistogramLegendPlot extends LegendPlot<void> {
     public draw(): void {
         this.plottingSurface.getCanvas()
             .append("text")
-            .text(this.axisData.getName(this.schema))
+            .text(this.axisData.getName())
             .attr("transform", `translate(${this.getChartWidth() / 2}, 0)`)
             .attr("text-anchor", "middle")
             .attr("dominant-baseline", "text-before-edge");
@@ -162,10 +160,9 @@ export class HistogramLegendPlot extends LegendPlot<void> {
         return (x) => this.colorMap(x / this.axisData.bucketCount);
     }
 
-    public setData(axis: AxisData, missingLegend: boolean, schema: SchemaClass): void {
+    public setData(axis: AxisData, missingLegend: boolean): void {
         this.axisData = axis;
         this.missingLegend = missingLegend;
-        this.schema = schema;
         if (kindIsString(axis.description.kind))
             this.setMap((d) => Plot.categoricalMap(Math.round(d * (this.axisData.bucketCount - 1))));
         else

--- a/web/src/main/webapp/ui/quartiles2DPlot.ts
+++ b/web/src/main/webapp/ui/quartiles2DPlot.ts
@@ -100,7 +100,7 @@ export class Quartiles2DPlot extends Plot<Groups<SampleSet>> {
         this.barWidth = chartWidth / bucketCount;
 
         this.plottingSurface.getCanvas().append("text")
-            .text(this.xAxisData.getName(this.schema))
+            .text(this.xAxisData.getName())
             .attr("transform", `translate(${this.getChartWidth() / 2},
             ${this.getChartHeight() + this.plottingSurface.topMargin + this.plottingSurface.bottomMargin / 2})`)
             .attr("text-anchor", "middle")

--- a/web/src/main/webapp/ui/quartiles2DPlot.ts
+++ b/web/src/main/webapp/ui/quartiles2DPlot.ts
@@ -100,7 +100,7 @@ export class Quartiles2DPlot extends Plot<Groups<SampleSet>> {
         this.barWidth = chartWidth / bucketCount;
 
         this.plottingSurface.getCanvas().append("text")
-            .text(this.xAxisData.getDisplayNameString(this.schema))
+            .text(this.xAxisData.getName(this.schema))
             .attr("transform", `translate(${this.getChartWidth() / 2},
             ${this.getChartHeight() + this.plottingSurface.topMargin + this.plottingSurface.bottomMargin / 2})`)
             .attr("text-anchor", "middle")

--- a/web/src/main/webapp/util.ts
+++ b/web/src/main/webapp/util.ts
@@ -134,8 +134,8 @@ export class Exporter {
         data: Groups<Groups<number>>, schema: SchemaClass, axis: AxisData[]): string[] {
         const lines: string[] = [];
 
-        const yAxis = schema.displayName(axis[1].description!.name);
-        const xAxis = schema.displayName(axis[0].description!.name);
+        const yAxis = axis[1].description!.name;
+        const xAxis = axis[0].description!.name;
         let line = "";
         for (let y = 0; y < axis[1].bucketCount; y++) {
             const by = axis[1].bucketDescription(y, 0);
@@ -165,11 +165,11 @@ export class Exporter {
         let lines = [];
         let line = "count";
         for (const o of order.sortOrientationList)
-            line += "," + JSON.stringify(schema.displayName(o.columnDescription.name)!.displayName);
+            line += "," + JSON.stringify(o.columnDescription.name);
         if (aggregates != null)
             for (const a of aggregates) {
                 // noinspection UnnecessaryLocalVariableJS
-                const dn = schema.displayName(a.cd.name)!.displayName;
+                const dn = a.cd.name;
                 line += "," + JSON.stringify(a.agkind + "(" + dn + "))");
             }
         lines.push(line);
@@ -197,8 +197,8 @@ export class Exporter {
 
     public static histogramAsCsv(data: Groups<number>, schema: SchemaClass, axis: AxisData): string[] {
         const lines: string[] = [];
-        const displayName = schema.displayName(axis.description.name);
-        let line = JSON.stringify(displayName!.displayName) + ",count";
+        const colName = axis.description.name;
+        let line = JSON.stringify(colName) + ",count";
         lines.push(line);
         for (let x = 0; x < data.perBucket.length; x++) {
             const bx = axis.bucketDescription(x, 0);
@@ -213,7 +213,7 @@ export class Exporter {
     public static histogram3DAsCsv(
         data: Groups<Groups<Groups<number>>>, schema: SchemaClass, axis: AxisData[]): string[] {
         let lines: string[] = [];
-        const gAxis = schema.displayName(axis[2].description!.name);
+        const gAxis = axis[2].description!.name;
         for (let g = 0; g < axis[2].bucketCount; g++) {
             const gl = Exporter.histogram2DAsCsv(data.perBucket[g], schema, axis);
             const first = gl[0];
@@ -234,7 +234,7 @@ export class Exporter {
     public static quartileAsCsv(g: Groups<SampleSet>, schema: SchemaClass, axis: AxisData): string[] {
         const lines: string[] = [];
         let line = "";
-        const axisName = schema.displayName(axis.description.name);
+        const axisName = axis.description.name;
         for (let x = 0; x < axis.bucketCount; x++) {
             const bx = axis.bucketDescription(x, 0);
             const l = JSON.stringify(axisName + " " + bx);
@@ -959,16 +959,6 @@ export function transpose<D>(m: D[][]): D[][] {
         result.push(v);
     }
     return result;
-}
-
-/**
- * Converts a map to an array by creating an array with an even number of elements
- * where the elements alternate keys and values [k0, v0, k1, v1, ...]
- */
-export function mapToArray<K, V>(map: Map<K, V>): any[] {
-    const res: any[] = [];
-    map.forEach((v, k) => { res.push(k); res.push(v); });
-    return res;
 }
 
 /**


### PR DESCRIPTION
Previously rename was a front-end-only operation, the front end had to maintain a map between the original column names and the new column names. This was a constant source of bugs. With this change the rename becomes a back-end operation, and the invariant is that the schema in the front-end always matches the schema in the back-end.