### PR TITLE
Remove erroneous pip install command

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -30,7 +30,6 @@ esac
 ${SUDO} ${INSTALL} install wget maven ${NODEJS} ${LIBFORTRAN} unzip gzip python3
 echo "Installing typescript compiler"
 ${SUDO} npm install -g typescript@3.9.7
-pip install json
 
 # Download apache if not there.
 pushd ..


### PR DESCRIPTION
`json` is a built-in python module and can't to be installed via `pip`.