### PR TITLE
Add github action for unit tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,30 @@
+name: Run unit tests
+
+on: [push, pull_request]
+
+jobs:
+  unit-tests:
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-18.04]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install java 8
+        run: sudo apt update && sudo apt install -y openjdk-8-jdk
+      - name: Check out the repository
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        working-directory: bin
+        run: ./install-dependencies.sh
+      - name: Build project
+        working-directory: bin
+        run: ./rebuild.sh -a
+      - name: Process demo data
+        working-directory: bin
+        run: ./demo-data-cleaner.sh
+      - name: Run unit tests
+        working-directory: bin
+        run: ./rebuild.sh -t
+        env:
+          JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64/

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -16,7 +16,7 @@ echo "Installing programs needed to build"
 case "${OSTYPE}" in
     linux*)
         echo "Installing curl"
-        ${SUDO} ${INSTALL} install curl -y
+        ${SUDO} ${INSTALL} install -y curl
         if [ "$(cat /etc/*-release | grep -Ec 'ubuntu|debian')" -ne 0 ]; then
             curl -sL https://deb.nodesource.com/setup_12.x | ${SUDO} -E bash -
 	elif [ "$(cat /etc/*-release | grep -c -e centos -e rhel )" -ne 0 ]; then
@@ -27,7 +27,7 @@ case "${OSTYPE}" in
         ;;
 esac
 
-${SUDO} ${INSTALL} install wget maven ${NODEJS} ${LIBFORTRAN} unzip gzip python3
+${SUDO} ${INSTALL} install -y wget maven ${NODEJS} ${LIBFORTRAN} unzip gzip python3
 echo "Installing typescript compiler"
 ${SUDO} npm install -g typescript@3.9.7
 


### PR DESCRIPTION
* Add GitHub action for unit tests
* Add `-y` flag to install command so no interaction is needed
* Implement a workaround for the problem that the ip range used for GitHub actions seem to have been blocked by bts.gov: if GitHub action environment is detected, download from internet archive instead.