### PR TITLE
Reformat scripts

### DIFF
--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -13,17 +13,17 @@ case "$OSTYPE" in
     linux*)
         LIBFORTRAN="libgfortran3"
         if [ "$(cat /etc/*-release | grep -Ec 'ubuntu|debian')" -ne 0 ]; then
-	    # Npm will be installed with node.js
-	    INSTALL="apt-get"; SUDO="sudo"; NODEJS="nodejs";
-	    if [ "$(lsb_release -d | grep -Ec 20)" -ne 0 ]; then
-	    	LIBFORTRAN="libgfortran5"
-	    fi
-	elif [ "$(cat /etc/*-release | grep -c -e centos -e rhel )" -ne 0 ]; then
-	    INSTALL="yum"; SUDO="sudo"; NODEJS="nodejs";
-	else
-	    echo "Unhandled operating system $OSTYPE"; exit 1;
-	fi
-	;;
-    darwin*) INSTALL="brew"; SUDO=""; NODEJS="node"; LIBFORTRAN="" ;;
-    *) echo "Unhandled operating system $OSTYPE"; exit 1;;
+            # Npm will be installed with node.js
+            INSTALL="apt-get"; SUDO="sudo"; NODEJS="nodejs";
+            if [ "$(lsb_release -d | grep -Ec 20)" -ne 0 ]; then
+                LIBFORTRAN="libgfortran5"
+            fi
+        elif [ "$(cat /etc/*-release | grep -Ec 'centos|rhel' )" -ne 0 ]; then
+            INSTALL="yum"; SUDO="sudo"; NODEJS="nodejs";
+        else
+            echo "Unhandled operating system $OSTYPE"; exit 1;
+        fi
+        ;;
+    darwin*) INSTALL="brew"; SUDO=""; NODEJS="node"; LIBFORTRAN=""; ;;
+    *) echo "Unhandled operating system $OSTYPE"; exit 1; ;;
 esac

--- a/bin/rebuild.sh
+++ b/bin/rebuild.sh
@@ -13,8 +13,6 @@ usage() {
 
 mydir="$(dirname -- "$0")"
 if [[ ! -d "$mydir" ]]; then mydir="$PWD"; fi
-# shellcheck source=./lib.sh
-source ${mydir}/lib.sh
 
 # Bail out on first error; verbose
 set -ex


### PR DESCRIPTION
* Converted all indents in `lib.sh` to spaces (used to be a mix of spaces and tabs).
* There is no need to source `lib.sh` in `rebuild.sh`, removed
