### PR TITLE
Fix bug in deploy.py

### DIFF
--- a/bin/deploy.py
+++ b/bin/deploy.py
@@ -115,7 +115,8 @@ def prepare_aggregator(config, rh):
         rh.copy_file_to_remote(
             config.scriptFolder +
             "/../platform/target/hillview-server-jar-with-dependencies.jar",
-            config.service_folder + "/hillview", "")
+            config.service_folder, "")
+        rh.copy_file_to_remote("forever.sh", config.service_folder, "")
     tmp = tempfile.NamedTemporaryFile(mode="w", delete=False)
     for h in rh.children:
         tmp.write(h + ":" + str(config.worker_port) + "\n")


### PR DESCRIPTION
* `hillview-aggregator-manager.sh` uses `forever.sh` but was not deployed
* `hillview-aggregator-manager.sh` assumes `hillview-server-jar-with-dependencies.jar` is at the root of service directory, but it's actually deployed to `service_directory/hillview/` is a node is only an aggregator but not a worker.