### PR TITLE
Fix typo in platform/pom.xml

### DIFF
--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -720,7 +720,7 @@
                 <configuration>
                     <rules>
                         <banDuplicatePomDependencyVersions/>
-                        <dependencyConverge/>
+                        <dependencyConvergence/>
                     </rules>
                 </configuration>
             </plugin>


### PR DESCRIPTION
The built-in rule is named `dependencyConvergence` rather than `dependencyConverge`.

Currently run `mvn enforcer:enforce` doesn't do anything, while after this patch it can show all the dependency conflicts.

Reference:
https://maven.apache.org/enforcer/enforcer-rules/dependencyConvergence.html