### PR TITLE
Implement writing table to parquet

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,7 +24,7 @@ jobs:
         run: ./rebuild.sh -a
       - name: Process demo data
         working-directory: bin
-        run: ./demo-data-cleaner.sh -g
+        run: ./demo-data-cleaner.sh -dp
       - name: Run unit tests
         working-directory: bin
         run: ./rebuild.sh -t

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ data/synthetic/privacy_metadata.json
 data/metadata/differential-privacy/data/ontime_private/privacy_metadata.json
 data/geo/us_states/cb_*
 data/geo/airports/airprt*
+data/parquet/
 
 *.DS_Store
 hillview_root_key

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ data/ontime_big/*.gz
 data/ontime/2016_*.csv
 data/ontime/*.orc
 data/ontime/*.crc
+data/ontime/*.parquet
 data/ontime/delta-table/
 data/ontime_orc/*
 data/ontime_small_orc/*

--- a/bin/demo-data-cleaner.sh
+++ b/bin/demo-data-cleaner.sh
@@ -10,20 +10,25 @@ pushd ../data/ontime
 ./download.py
 popd
 
-while getopts "g" opt; do
+ARGS=""
+while getopts "dp" opt; do
   case "$opt" in
-    g)
+    d)
       python3 generate-delta-table.py
       ;;
+    p)
+      ARGS+="-Dparquet.enabled "
+      ;;
     *)
-      echo "demo-data-cleaner.sh [-g]"
-      echo "This script runs the java class DemoDataCleaner to prepare data for testing/demo purposes"
-      echo "-g: Also generate a delta table for testing, requires python3, pyspark, and delta-spark"
+      echo "Usage: demo-data-cleaner.sh [-g]"
+      echo "This script runs the java class DemoDataCleaner to prepare data for testing/demo purposes."
+      echo "-d: Also generate a delta table for testing, requires python3, pyspark, and delta-spark."
+      echo "-p: Also generate parquet files for testing."
       exit 1
       ;;
   esac
 done
 
 pushd ../platform
-java -jar target/data-cleaner-jar-with-dependencies.jar
+java -jar ${ARGS} target/data-cleaner-jar-with-dependencies.jar
 popd

--- a/bin/demo-data-cleaner.sh
+++ b/bin/demo-data-cleaner.sh
@@ -20,7 +20,7 @@ while getopts "dp" opt; do
       ARGS+="-Dparquet.enabled "
       ;;
     *)
-      echo "Usage: demo-data-cleaner.sh [-g]"
+      echo "Usage: demo-data-cleaner.sh [-d] [-p]"
       echo "This script runs the java class DemoDataCleaner to prepare data for testing/demo purposes."
       echo "-d: Also generate a delta table for testing, requires python3, pyspark, and delta-spark."
       echo "-p: Also generate parquet files for testing."

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -404,6 +404,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-avro</artifactId>
+            <version>1.11.1</version>
+        </dependency>
         <!-- Delta lake -->
         <dependency>
             <groupId>io.delta</groupId>

--- a/platform/src/main/java/org/hillview/storage/ParquetFileWriter.java
+++ b/platform/src/main/java/org/hillview/storage/ParquetFileWriter.java
@@ -1,0 +1,115 @@
+package org.hillview.storage;
+
+import org.apache.avro.generic.GenericData;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.avro.AvroParquetWriter;
+import org.apache.parquet.avro.AvroSchemaConverter;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
+import org.hillview.table.ColumnDescription;
+import org.hillview.table.Schema;
+import org.hillview.table.api.IColumn;
+import org.hillview.table.api.IRowIterator;
+import org.hillview.table.api.ITable;
+
+import java.io.IOException;
+import java.util.List;
+
+public class ParquetFileWriter implements ITableWriter {
+    private final String filepath;
+
+    public ParquetFileWriter(String filepath) {
+        this.filepath = filepath;
+    }
+
+    private static MessageType getMessageType(Schema schema) {
+        Types.MessageTypeBuilder builder = Types.buildMessage();
+
+        for (ColumnDescription description : schema.getColumnDescriptions()) {
+            switch (description.kind) {
+                case Date:
+                case Double:
+                case Duration:
+                case LocalDate:
+                case Time:
+                    builder.optional(PrimitiveType.PrimitiveTypeName.DOUBLE).named(description.name);
+                    break;
+                case Integer:
+                    builder.optional(PrimitiveType.PrimitiveTypeName.INT32).named(description.name);
+                    break;
+                case Json:
+                case String:
+                    builder.optional(PrimitiveType.PrimitiveTypeName.BINARY)
+                            .as(LogicalTypeAnnotation.stringType())
+                            .named(description.name);
+                    break;
+                case Interval:
+                case None:
+                default:
+                    throw new RuntimeException("Unsupported type: " + description.kind);
+            }
+        }
+
+        // Not sure if this name should be made a variable
+        return builder.named("schema");
+    }
+
+    @Override
+    public void writeTable(ITable table) {
+        MessageType messageType = getMessageType(table.getSchema());
+        org.apache.avro.Schema avroSchema = new AvroSchemaConverter().convert(messageType);
+        List<IColumn> cols = table.getLoadedColumns(table.getSchema().getColumnNames());
+
+        try {
+            ParquetWriter<GenericData.Record> writer = AvroParquetWriter.<GenericData.Record>builder(new Path(filepath))
+                    .withSchema(avroSchema)
+                    .withCompressionCodec(CompressionCodecName.SNAPPY)
+                    .build();
+
+            IRowIterator iterator = table.getMembershipSet().getIterator();
+            int nextRow = iterator.getNextRow();
+            while (nextRow >= 0) {
+                GenericData.Record record = new GenericData.Record(avroSchema);
+                for (int i = 0; i < cols.size(); i++) {
+                    IColumn col = cols.get(i);
+
+                    if (col.isMissing(nextRow)) {
+                        record.put(col.getName(), null);
+                        continue;
+                    }
+
+                    switch (col.getKind()) {
+                        case Date:
+                        case Double:
+                        case Duration:
+                        case LocalDate:
+                        case Time:
+                            record.put(col.getName(), col.getDouble(nextRow));
+                            break;
+                        case Integer:
+                            record.put(col.getName(), col.getInt(nextRow));
+                            break;
+                        case Json:
+                        case String:
+                            record.put(col.getName(), col.getString(nextRow));
+                            break;
+                        case Interval:
+                        case None:
+                        default:
+                            throw new RuntimeException("Unsupported type: " + col.getKind());
+                    }
+                }
+
+                writer.write(record);
+                nextRow = iterator.getNextRow();
+            }
+            writer.close();
+        } catch (IOException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+}

--- a/platform/src/main/java/org/hillview/table/columns/DoubleArrayColumn.java
+++ b/platform/src/main/java/org/hillview/table/columns/DoubleArrayColumn.java
@@ -41,7 +41,6 @@ public class DoubleArrayColumn
     public DoubleArrayColumn(final ColumnDescription description,
                              final double[] data) {
         super(description, data.length);
-        this.checkKind(ContentsKind.Double);
         this.data = data;
     }
 

--- a/platform/src/main/java/org/hillview/utils/Converters.java
+++ b/platform/src/main/java/org/hillview/utils/Converters.java
@@ -28,6 +28,8 @@ import java.util.Locale;
 public class Converters {
     public static final long NANOS_TO_SECONDS = 1_000_000_000;
     public static final int NANOS_TO_MILLIS = 1_000_000;
+    public static final int MICROS_TO_MILLIS = 1_000;
+    public static final int MILLIS_TO_SECONDS = 1_000;
     public static final int SECONDS_TO_DAY = 24 * 3600;
 
     private static final LocalDateTime baseLocalTime = LocalDateTime.of(

--- a/platform/src/test/java/org/hillview/test/TestUtil.java
+++ b/platform/src/test/java/org/hillview/test/TestUtil.java
@@ -80,7 +80,7 @@ public class TestUtil {
         Percentiles(results);
     }
 
-    private static IColumn getRandDateArray(int size, String colName) {
+    public static IColumn getRandDateArray(int size, String colName) {
         final ColumnDescription desc = new ColumnDescription(colName, ContentsKind.Date);
         double[] data = new double[size];
         final Randomness rn = new Randomness(0);

--- a/platform/src/test/java/org/hillview/test/storage/ParquetTest.java
+++ b/platform/src/test/java/org/hillview/test/storage/ParquetTest.java
@@ -25,48 +25,38 @@ import org.hillview.test.BaseTest;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 public class ParquetTest extends BaseTest {
     // Not yet checked-in into the repository
-    private static final String path = dataDir + "/parquet/" +
-            "part-r-00000-9d5cd245-a2e4-4002-9d58-0efdfb0fb962.gz.parquet";
+    private static final Path path = Paths.get(dataDir, "ontime", "2016_1.parquet");
 
     @Test
     public void readTest() {
-        ITable table;
-        try {
-            ParquetFileLoader pr = new ParquetFileLoader(path, false);
-            table = pr.load();
-        } catch (Exception ex) {
-            // If the file is not present do not fail the test.
-            return;
-        }
+        ParquetFileLoader pr = new ParquetFileLoader(path.toString(), false);
+        ITable table = pr.load();
 
         Assert.assertNotNull(table);
-        Assert.assertEquals("Table[18x4214]", table.toString());
-        IColumn first = table.getLoadedColumn("java_version");
-        Assert.assertEquals(first.getString(0), "1.8.0_91");
+        Assert.assertEquals("Table[15x445827]", table.toString());
+        IColumn first = table.getLoadedColumn("OriginCityName");
+        Assert.assertEquals("Dallas/Fort Worth, TX", first.getString(0));
         if (toPrint) {
-            System.out.println(table.getSchema().toString());
+            System.out.println(table.getSchema());
             System.out.println(table.toLongString(100));
         }
     }
 
     @Test
     public void lazyReadTest() {
-        ITable table;
-        try {
-            ParquetFileLoader pr = new ParquetFileLoader(path, true);
-            table = pr.load();
-        } catch (Exception ex) {
-            // If the file is not present do not fail the test.
-            return;
-        }
+        ParquetFileLoader pr = new ParquetFileLoader(path.toString(), true);
+        ITable table = pr.load();
 
         Assert.assertNotNull(table);
-        Assert.assertEquals("Table[18x4214]", table.toString());
-        IColumn first = table.getLoadedColumn("java_version");
-        Assert.assertEquals(first.getString(0), "1.8.0_91");
-        Table tbl = (Table)table;
+        Assert.assertEquals("Table[15x445827]", table.toString());
+        IColumn first = table.getLoadedColumn("OriginCityName");
+        Assert.assertEquals(first.getString(0), "Dallas/Fort Worth, TX");
+        Table tbl = (Table) table;
         Assert.assertFalse(tbl.getColumns().get(1).isLoaded());
     }
 }

--- a/platform/src/test/java/org/hillview/test/storage/ParquetTest.java
+++ b/platform/src/test/java/org/hillview/test/storage/ParquetTest.java
@@ -34,8 +34,14 @@ public class ParquetTest extends BaseTest {
 
     @Test
     public void readTest() {
-        ParquetFileLoader pr = new ParquetFileLoader(path.toString(), false);
-        ITable table = pr.load();
+        ITable table;
+        try {
+            ParquetFileLoader pr = new ParquetFileLoader(path.toString(), false);
+            table = pr.load();
+        } catch (Exception ex) {
+            // If the file is not present do not fail the test.
+            return;
+        }
 
         Assert.assertNotNull(table);
         Assert.assertEquals("Table[15x445827]", table.toString());
@@ -49,8 +55,14 @@ public class ParquetTest extends BaseTest {
 
     @Test
     public void lazyReadTest() {
-        ParquetFileLoader pr = new ParquetFileLoader(path.toString(), true);
-        ITable table = pr.load();
+        ITable table;
+        try {
+            ParquetFileLoader pr = new ParquetFileLoader(path.toString(), true);
+            table = pr.load();
+        } catch (Exception ex) {
+            // If the file is not present do not fail the test.
+            return;
+        }
 
         Assert.assertNotNull(table);
         Assert.assertEquals("Table[15x445827]", table.toString());

--- a/platform/src/test/java/org/hillview/test/storage/ParquetTest.java
+++ b/platform/src/test/java/org/hillview/test/storage/ParquetTest.java
@@ -18,25 +18,40 @@
 package org.hillview.test.storage;
 
 import org.hillview.storage.ParquetFileLoader;
+import org.hillview.storage.ParquetFileWriter;
+import org.hillview.table.ColumnDescription;
 import org.hillview.table.Table;
+import org.hillview.table.api.ContentsKind;
 import org.hillview.table.api.IColumn;
 import org.hillview.table.api.ITable;
+import org.hillview.table.columns.DoubleArrayColumn;
+import org.hillview.table.columns.IntArrayColumn;
+import org.hillview.table.columns.StringArrayColumn;
 import org.hillview.test.BaseTest;
+import org.hillview.test.TestUtil;
+import org.hillview.utils.Converters;
+import org.hillview.utils.Randomness;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ParquetTest extends BaseTest {
     // Not yet checked-in into the repository
-    private static final Path path = Paths.get(dataDir, "ontime", "2016_1.parquet");
+    private static final Path parquetInputFile = Paths.get(dataDir, "ontime", "2016_1.parquet");
+
+    private static final Path parquetOutputFile = Paths.get(dataDir, "parquet", "test.parquet");
 
     @Test
     public void readTest() {
         ITable table;
         try {
-            ParquetFileLoader pr = new ParquetFileLoader(path.toString(), false);
+            ParquetFileLoader pr = new ParquetFileLoader(parquetInputFile.toString(), false);
             table = pr.load();
         } catch (Exception ex) {
             // If the file is not present do not fail the test.
@@ -57,7 +72,7 @@ public class ParquetTest extends BaseTest {
     public void lazyReadTest() {
         ITable table;
         try {
-            ParquetFileLoader pr = new ParquetFileLoader(path.toString(), true);
+            ParquetFileLoader pr = new ParquetFileLoader(parquetInputFile.toString(), true);
             table = pr.load();
         } catch (Exception ex) {
             // If the file is not present do not fail the test.
@@ -70,5 +85,77 @@ public class ParquetTest extends BaseTest {
         Assert.assertEquals(first.getString(0), "Dallas/Fort Worth, TX");
         Table tbl = (Table) table;
         Assert.assertFalse(tbl.getColumns().get(1).isLoaded());
+    }
+
+    @Test
+    public void writeTest() throws IOException {
+        Files.deleteIfExists(parquetOutputFile);
+        Randomness rn = new Randomness(1234);
+        List<IColumn> columnList = new ArrayList<>();
+
+        ColumnDescription intColumnDescription = new ColumnDescription("Int", ContentsKind.Integer);
+        IntArrayColumn intArrayColumn = new IntArrayColumn(intColumnDescription, 2);
+        intArrayColumn.set(0, rn.nextInt());
+        intArrayColumn.set(1, rn.nextInt());
+        columnList.add(intArrayColumn);
+
+        ColumnDescription stringColumnDescription = new ColumnDescription("String", ContentsKind.String);
+        StringArrayColumn stringArrayColumn = new StringArrayColumn(stringColumnDescription, 2);
+        stringArrayColumn.set(0, "something");
+        stringArrayColumn.set(1, null);
+        columnList.add(stringArrayColumn);
+
+        columnList.add(TestUtil.getRandDateArray(2, "Date"));
+
+        ColumnDescription timeColumnDescription = new ColumnDescription("Time", ContentsKind.Time);
+        DoubleArrayColumn timeArrayColumn = new DoubleArrayColumn(timeColumnDescription, 2);
+        timeArrayColumn.set(0, (double) rn.nextInt(Converters.SECONDS_TO_DAY * Converters.MILLIS_TO_SECONDS));
+        timeArrayColumn.set(1, (double) rn.nextInt(Converters.SECONDS_TO_DAY * Converters.MILLIS_TO_SECONDS));
+        columnList.add(timeArrayColumn);
+
+        ColumnDescription jsonColumnDescription = new ColumnDescription("Json", ContentsKind.Json);
+        StringArrayColumn jsonArrayColumn = new StringArrayColumn(jsonColumnDescription, 2);
+        jsonArrayColumn.set(0, "{\n" +
+                "  \"cloud\": \"if\",\n" +
+                "  \"brown\": 216284933.78439975,\n" +
+                "  \"neck\": true,\n" +
+                "  \"recent\": true,\n" +
+                "  \"manufacturing\": 405661684.64231133,\n" +
+                "  \"nine\": -1257746979.641677\n" +
+                "}" );
+        jsonArrayColumn.set(1, "{\n" +
+                "  \"chance\": 239690427,\n" +
+                "  \"outline\": -555912547,\n" +
+                "  \"alone\": [\n" +
+                "    true,\n" +
+                "    \"progress\",\n" +
+                "    1291815253.6504672,\n" +
+                "    \"hidden\",\n" +
+                "    [\n" +
+                "      \"according\",\n" +
+                "      -258144348.32382202,\n" +
+                "      -280375743.720135,\n" +
+                "      \"garage\",\n" +
+                "      \"sick\",\n" +
+                "      1215321142\n" +
+                "    ],\n" +
+                "    -311046396.6782801\n" +
+                "  ],\n" +
+                "  \"wooden\": \"myself\",\n" +
+                "  \"go\": \"colony\",\n" +
+                "  \"welcome\": true\n" +
+                "}");
+        columnList.add(jsonArrayColumn);
+
+        ITable originalTable = new Table(columnList, null, null);
+        ParquetFileWriter writer = new ParquetFileWriter(parquetOutputFile.toString());
+        writer.writeTable(originalTable);
+
+        ParquetFileLoader loader = new ParquetFileLoader(parquetOutputFile.toString(), false);
+        ITable processedTable = loader.load();
+
+        Assert.assertNotNull(processedTable);
+        Assert.assertEquals(originalTable.toLongString(originalTable.getNumOfRows()),
+                processedTable.toLongString(processedTable.getNumOfRows()));
     }
 }


### PR DESCRIPTION
* Implement `ParquetFileWriter` that can write an `ITable` to a `.parquet` file.
* Generate test parquet files in `DemoDataCleaner` (closes #346).
* Modified `ParquetTest` to use the generated parquet file.