### PR TITLE
Add distinct count to basic column stats

### DIFF
--- a/platform/src/main/java/org/hillview/sketches/HLogLogSketch.java
+++ b/platform/src/main/java/org/hillview/sketches/HLogLogSketch.java
@@ -30,6 +30,8 @@ import javax.annotation.Nullable;
 public class HLogLogSketch implements TableSketch<HLogLog> {
     static final long serialVersionUID = 1;
 
+    static public final int DEFAULT_LOG_SPACE_SIZE = 12;
+
     private final String colName;
     private final long seed; //seed for the hash function of the HLogLog
     /**
@@ -41,7 +43,7 @@ public class HLogLogSketch implements TableSketch<HLogLog> {
     private final ColumnQuantization quantization;
 
     public HLogLogSketch(String colName, long seed) {
-        this(colName, 12, seed, null);
+        this(colName, DEFAULT_LOG_SPACE_SIZE, seed, null);
     }
 
     public HLogLogSketch(String colName, int logSpaceSize, long seed,

--- a/platform/src/test/java/org/hillview/test/dataset/BasicStatSketchTest.java
+++ b/platform/src/test/java/org/hillview/test/dataset/BasicStatSketchTest.java
@@ -18,30 +18,34 @@
 package org.hillview.test.dataset;
 
 import org.hillview.dataset.api.IDataSet;
-import org.hillview.sketches.*;
+import org.hillview.sketches.BasicColStatSketch;
 import org.hillview.sketches.results.BasicColStats;
-import org.hillview.test.BaseTest;
-import org.hillview.utils.JsonList;
-import org.hillview.utils.TestTables;
+import org.hillview.sketches.results.HLogLog;
 import org.hillview.table.SmallTable;
 import org.hillview.table.Table;
 import org.hillview.table.api.ITable;
+import org.hillview.test.BaseTest;
+import org.hillview.utils.JsonList;
+import org.hillview.utils.Pair;
+import org.hillview.utils.TestTables;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertTrue;
+
 public class BasicStatSketchTest extends BaseTest {
+    private static final long seed = 0;
+
     @Test
     public void StatSketchTest() {
         final int numCols = 1;
         final int tableSize = 1000;
         final Table myTable = TestTables.getRepIntTable(tableSize, numCols);
-        final BasicColStatSketch mySketch = new BasicColStatSketch(
-                myTable.getSchema().getColumnNames().get(0),
-                0);
-        JsonList<BasicColStats> result = mySketch.create(myTable);
+        final BasicColStatSketch mySketch = new BasicColStatSketch(myTable.getSchema().getColumnNames().get(0), 0, seed);
+        JsonList<Pair<BasicColStats, HLogLog>> result = mySketch.create(myTable);
         Assert.assertNotNull(result);
         Assert.assertEquals(1, result.size());
-        Assert.assertEquals(result.get(0).getPresentCount(), 1000);
+        Assert.assertEquals(result.get(0).first.getPresentCount(), 1000);
     }
 
     @Test
@@ -52,16 +56,18 @@ public class BasicStatSketchTest extends BaseTest {
         final String colName = bigTable.getSchema().getColumnNames().get(0);
 
         IDataSet<ITable> all = TestTables.makeParallel(bigTable, bigSize / 10);
-        JsonList<BasicColStats> result = all.blockingSketch(
-                new BasicColStatSketch(colName, 1));
+        JsonList<Pair<BasicColStats, HLogLog>> result = all.blockingSketch(
+                new BasicColStatSketch(colName, 1, seed));
         BasicColStatSketch mySketch = new BasicColStatSketch(
-                bigTable.getSchema().getColumnNames().get(0), 1);
-        JsonList<BasicColStats> result1 = mySketch.create(bigTable);
+                bigTable.getSchema().getColumnNames().get(0), 1, seed);
+        JsonList<Pair<BasicColStats, HLogLog>> result1 = mySketch.create(bigTable);
         Assert.assertNotNull(result);
         Assert.assertNotNull(result1);
         Assert.assertEquals(1, result.size());
         Assert.assertEquals(1, result1.size());
-        Assert.assertEquals(result.get(0).getMoment(1), result1.get(0).getMoment(1), 0.001);
+        Assert.assertEquals(result.get(0).first.getMoment(1), result1.get(0).first.getMoment(1), 0.001);
+        assertTrue(result.get(0).second.distinctItemsEstimator() > 85000);
+        assertTrue(result1.get(0).second.distinctItemsEstimator() > 85000);
     }
 
     @Test
@@ -70,11 +76,11 @@ public class BasicStatSketchTest extends BaseTest {
         String colName = bigTable.getSchema().getColumnNames().get(0);
 
         IDataSet<ITable> all = TestTables.makeParallel(bigTable, 5);
-        JsonList<BasicColStats> result = all.blockingSketch(
-                new BasicColStatSketch(colName, 1));
+        JsonList<Pair<BasicColStats, HLogLog>> result = all.blockingSketch(
+                new BasicColStatSketch(colName, 1, seed));
         Assert.assertNotNull(result);
         Assert.assertEquals(1, result.size());
-        Assert.assertEquals("Tom", result.get(0).maxString);
-        Assert.assertEquals("Bill", result.get(0).minString);
+        Assert.assertEquals("Tom", result.get(0).first.maxString);
+        Assert.assertEquals("Bill", result.get(0).first.minString);
     }
 }

--- a/platform/src/test/java/org/hillview/test/dataset/BasicStatSketchTest.java
+++ b/platform/src/test/java/org/hillview/test/dataset/BasicStatSketchTest.java
@@ -31,8 +31,6 @@ import org.hillview.utils.TestTables;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
-
 public class BasicStatSketchTest extends BaseTest {
     private static final long seed = 0;
 
@@ -66,8 +64,8 @@ public class BasicStatSketchTest extends BaseTest {
         Assert.assertEquals(1, result.size());
         Assert.assertEquals(1, result1.size());
         Assert.assertEquals(result.get(0).first.getMoment(1), result1.get(0).first.getMoment(1), 0.001);
-        assertTrue(result.get(0).second.distinctItemsEstimator() > 85000);
-        assertTrue(result1.get(0).second.distinctItemsEstimator() > 85000);
+        Assert.assertTrue(result.get(0).second.distinctItemsEstimator() > 85000);
+        Assert.assertTrue(result1.get(0).second.distinctItemsEstimator() > 85000);
     }
 
     @Test

--- a/platform/src/test/java/org/hillview/test/dataset/HyperLogLogTest.java
+++ b/platform/src/test/java/org/hillview/test/dataset/HyperLogLogTest.java
@@ -31,8 +31,6 @@ import org.hillview.utils.TestTables;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
 /**
  * Tests the hyper-log-log algorithm.
  */
@@ -50,8 +48,8 @@ public class HyperLogLogTest extends BaseTest {
         hll.createHLL(col, memSet);
         long alsoResult = hll.distinctItemCount;
         long result = hll.distinctItemsEstimator();
-        assertEquals(alsoResult, result);
-        assertTrue((result > (0.9 * range)) && (result < (1.1 * range)));
+        Assert.assertEquals(alsoResult, result);
+        Assert.assertTrue((result > (0.9 * range)) && (result < (1.1 * range)));
     }
 
     @Test
@@ -63,6 +61,6 @@ public class HyperLogLogTest extends BaseTest {
         final ParallelDataSet<ITable> all = TestTables.makeParallel(bigTable, bigSize / 10);
         final HLogLog hll = all.blockingSketch(new HLogLogSketch(colName, 16, 12345678, null));
         Assert.assertNotNull(hll);
-        assertTrue(hll.distinctItemsEstimator() > 85000);
+        Assert.assertTrue(hll.distinctItemsEstimator() > 85000);
     }
 }

--- a/web/src/main/webapp/dataViews/schemaView.ts
+++ b/web/src/main/webapp/dataViews/schemaView.ts
@@ -188,7 +188,7 @@ export class SchemaView extends TSViewBase {
                 "Standard deviation", "Number of missing elements");
         }
         if (this.counts != null) {
-            names.push("DistinctCount");
+            names.push("~DistinctCount");
             descriptions.push("Estimated number of distinct values");
         }
         this.display.setColumns(names, descriptions);

--- a/web/src/main/webapp/tableTarget.ts
+++ b/web/src/main/webapp/tableTarget.ts
@@ -257,8 +257,10 @@ export class TableTargetAPI extends RemoteObject {
             { columnName: colName, seed: Seed.instance.get() });
     }
 
-    public createBasicColStatsRequest(cols: string[]): RpcRequest<BasicColStats[]> {
-        return this.createStreamingRpcRequest<BasicColStats[]>("basicColStats", cols);
+    public createBasicColStatsRequest(cols: string[]): RpcRequest<Pair<BasicColStats, CountWithConfidence>[]> {
+        return this.createStreamingRpcRequest<Pair<BasicColStats, CountWithConfidence>[]>(
+            "basicColStats",
+            { cols: cols, seeds: cols.map(c => Seed.instance.get())});
     }
 
     public createHeavyHittersRequest(columns: IColumnDescription[],


### PR DESCRIPTION
Added distinct count to basic column stats. Implemented both backend and frontend.
The main change is that the signature of `BasicColStatSketch` is changed from `TableSketch<JsonList<BasicColStats>>` to `TableSketch<JsonList<Pair<BasicColStats, HLogLog>>>`

screenshot:
![Screenshot 2021-07-30 at 00-21-31 Hillview](https://user-images.githubusercontent.com/25761459/127600956-21adcb56-b79e-4420-b84f-dbc392e36841.png)

Resolves #708