### PR TITLE
Skip DeltaTableTest if a table is not found

### DIFF
--- a/platform/src/test/java/org/hillview/test/storage/DeltaTableTest.java
+++ b/platform/src/test/java/org/hillview/test/storage/DeltaTableTest.java
@@ -28,6 +28,10 @@ public class DeltaTableTest extends BaseTest {
 
     @Test
     public void readTest() {
+        if (!deltaTablePath.toFile().isDirectory()) {
+            // Delta table directory not present, don't fail the test
+            return;
+        }
         Empty e = Empty.getInstance();
         LocalDataSet<Empty> local = new LocalDataSet<>(e);
         DeltaTableDescription description = new DeltaTableDescription();
@@ -43,6 +47,6 @@ public class DeltaTableTest extends BaseTest {
         IDataSet<ITable> mapped = found.blockingMap(loader);
         SummarySketch sk = new SummarySketch();
         TableSummary tableSummary = mapped.blockingSketch(sk);
-        Assert.assertEquals(tableSummary.rowCount, 1_315_543);
+        Assert.assertEquals(1_315_543, tableSummary.rowCount);
     }
 }


### PR DESCRIPTION
Since generate a delta table is optional in `demo-data-cleaner.sh`, the `DeltaTableTest` shouldn't fail if a delta table is not found.