### PR TITLE
Use the same seed when estimating distint count

### DIFF
--- a/platform/src/main/java/org/hillview/sketches/BasicColStatSketch.java
+++ b/platform/src/main/java/org/hillview/sketches/BasicColStatSketch.java
@@ -35,18 +35,18 @@ public class BasicColStatSketch implements TableSketch<JsonList<Pair<BasicColSta
     static final long serialVersionUID = 1;
     private final String[] cols;
     private final int momentNum;
-    private final long[] seeds;
+    private final long seed;
 
-    public BasicColStatSketch(String[] cols, int momentNum, long[] seeds) {
+    public BasicColStatSketch(String[] cols, int momentNum, long seed) {
         this.cols = cols;
         this.momentNum = momentNum;
-        this.seeds = seeds;
+        this.seed = seed;
     }
 
     public BasicColStatSketch(String col, int momentNum, long seed) {
         this.cols = new String[] { col };
         this.momentNum = momentNum;
-        this.seeds = new long[] { seed };
+        this.seed = seed;
     }
 
     @Override
@@ -68,7 +68,7 @@ public class BasicColStatSketch implements TableSketch<JsonList<Pair<BasicColSta
         for (int i = 0; i < this.cols.length; i++)
             result.add(new Pair<>(
                     new BasicColStats(this.momentNum, true),
-                    new HLogLog(HLogLogSketch.DEFAULT_LOG_SPACE_SIZE, seeds[i])
+                    new HLogLog(HLogLogSketch.DEFAULT_LOG_SPACE_SIZE, seed)
             ));
 
         return result;

--- a/platform/src/test/java/org/hillview/test/dataset/PCATest.java
+++ b/platform/src/test/java/org/hillview/test/dataset/PCATest.java
@@ -29,7 +29,6 @@ import org.jblas.DoubleMatrix;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class PCATest extends BaseTest {
@@ -38,13 +37,11 @@ public class PCATest extends BaseTest {
         int size = 10;
         int numFrags = 1;
         int numCols  = 3;
-        long[] seeds = new long[numCols];
-        Arrays.fill(seeds, 0);
         ITable table = TestTables.getLinearTable(size, numCols);
         List<String> colNameList = table.getSchema().getColumnNames();
         String[] colNames = Utilities.toArray(colNameList);
         IDataSet<ITable> dataset = TestTables.makeParallel(table, size/numFrags);
-        BasicColStatSketch statsSk = new BasicColStatSketch(colNames, 0, seeds);
+        BasicColStatSketch statsSk = new BasicColStatSketch(colNames, 0, 0);
         JsonList<Pair<BasicColStats, HLogLog>> stats = dataset.blockingSketch(statsSk);
         Assert.assertNotNull(stats);
         JsonList<DoubleHistogramBuckets> buckets =

--- a/web/src/main/java/org/hillview/targets/TableTarget.java
+++ b/web/src/main/java/org/hillview/targets/TableTarget.java
@@ -106,13 +106,13 @@ public class TableTarget extends TableRpcTarget {
 
     static class BasicColStatsArgs {
         String[] cols;
-        long[] seeds;
+        long seed;
     }
 
     @HillviewRpc
     public void basicColStats(RpcRequest request, RpcRequestContext context) {
         BasicColStatsArgs args = request.parseArgs(BasicColStatsArgs.class);
-        BasicColStatSketch sk = new BasicColStatSketch(args.cols, 2, args.seeds);
+        BasicColStatSketch sk = new BasicColStatSketch(args.cols, 2, args.seed);
         PostProcessedSketch<ITable, JsonList<Pair<BasicColStats, HLogLog>>, JsonList<Pair<BasicColStats, CountWithConfidence>>> post =
                 sk.andThen(stats -> {
                     JsonList<Pair<BasicColStats, CountWithConfidence>> results = new JsonList<>();

--- a/web/src/main/webapp/tableTarget.ts
+++ b/web/src/main/webapp/tableTarget.ts
@@ -260,7 +260,7 @@ export class TableTargetAPI extends RemoteObject {
     public createBasicColStatsRequest(cols: string[]): RpcRequest<Pair<BasicColStats, CountWithConfidence>[]> {
         return this.createStreamingRpcRequest<Pair<BasicColStats, CountWithConfidence>[]>(
             "basicColStats",
-            { cols: cols, seeds: cols.map(c => Seed.instance.get())});
+            { cols: cols, seed: Seed.instance.get()});
     }
 
     public createHeavyHittersRequest(columns: IColumnDescription[],


### PR DESCRIPTION
Use the same seed for all columns instead of using a different seed for each column.