### PR TITLE
Specify versions for pyspark and delta-spark

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: bin
         run: ./install-dependencies.sh
       - name: Install dependencies for generating delta table
-        run: pip3 install --user pyspark delta-spark
+        run: pip3 install --user pyspark==3.1.2 delta-spark==1.0.0
       - name: Build project
         working-directory: bin
         run: ./rebuild.sh -a

--- a/bin/append-to-delta-table.py
+++ b/bin/append-to-delta-table.py
@@ -11,7 +11,7 @@ except ModuleNotFoundError:
     print(textwrap.dedent("""\
     This script requires pyspark and delta-spark.
     You can install these modules using the following command:
-        pip install --user pyspark delta-spark
+        pip install --user pyspark==3.1.2 delta-spark==1.0.0
     """), file=sys.stderr)
     sys.exit(-1)
 


### PR DESCRIPTION
Spark has a new release 3.2.0 and delta lake isn't compatible with it yet. This patch fixes the versions of both packages.